### PR TITLE
Ensure flashlight toggle input is collected automatically

### DIFF
--- a/Assets/Scripts/Items/FlashlightController.cs
+++ b/Assets/Scripts/Items/FlashlightController.cs
@@ -1,0 +1,288 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[DisallowMultipleComponent]
+public class FlashlightController : MonoBehaviour
+{
+    [Header("Fener Kurulumu")]
+    [Tooltip("F tuşuyla üretilecek fener prefabı.")]
+    [SerializeField] GameObject flashlightPrefab;
+
+    [Tooltip("Fenerin varsayılan olarak bağlanacağı soket (isteğe bağlı).")]
+    [SerializeField] Transform flashlightSocket;
+
+    [Tooltip("Soket atanmadığında karakter pozisyonuna uygulanacak ofset.")]
+    [SerializeField] Vector2 spawnOffset = new(0.25f, 0.45f);
+
+    [Header("Davranış")]
+    [Tooltip("Açıksa fener fare konumuna taşınır, kapalıysa pivotta kalarak yalnızca döner.")]
+    [SerializeField] bool followCursorPosition = false;
+
+    [Tooltip("Takip modunda fenerin oyuncudan uzaklaşabileceği azami mesafe (dünya birimi).")]
+    [SerializeField] float maxDistance = 6f;
+
+    [Tooltip("Fener örneğinin Z ekseninde tutulacağı sabit değer.")]
+    [SerializeField] float zDepth = 0f;
+
+    [Tooltip("Fener yalnızca karakter aktif kontrol altındayken açılabilsin mi?")]
+    [SerializeField] bool onlyWhenActiveControlled = true;
+
+    [Tooltip("Time.timeScale ≤ 0 olduğunda güncelleme döngüsü çalıştırılmaz.")]
+    [SerializeField] bool respectPauseState = true;
+
+    [Tooltip("Aktif karakter bilgisini sağlayan PartyController/InputRouter benzeri bileşen (isteğe bağlı).")]
+    [SerializeField] MonoBehaviour activeControlProvider;
+
+    InputAdapter input;
+    Camera cachedCamera;
+    Mouse cachedMouse;
+    Transform flashlightInstance;
+    IActiveCharacterGate controlGate;
+    bool warnedInvalidProvider;
+
+    public interface IActiveCharacterGate
+    {
+        bool IsCharacterActive(GameObject character);
+    }
+
+    void Awake()
+    {
+        input = GetComponent<InputAdapter>();
+        cachedCamera = Camera.main;
+        cachedMouse = Mouse.current;
+        CacheControlGate();
+    }
+
+    void OnEnable()
+    {
+        if (cachedCamera == null)
+        {
+            cachedCamera = Camera.main;
+        }
+
+        if (cachedMouse == null)
+        {
+            cachedMouse = Mouse.current;
+        }
+    }
+
+    void OnValidate() => CacheControlGate();
+
+    void OnDisable() => ShutdownInstance();
+
+    void OnDestroy() => ShutdownInstance();
+
+    void Update()
+    {
+        if (respectPauseState && Time.timeScale <= 0f)
+        {
+            return;
+        }
+
+        if (input == null)
+        {
+            return;
+        }
+
+        bool hasControl = !onlyWhenActiveControlled || HasControlAuthority();
+
+        if (input.FlashlightTogglePressed && hasControl)
+        {
+            Toggle();
+        }
+
+        if (!hasControl && flashlightInstance != null)
+        {
+            ShutdownInstance();
+            return;
+        }
+
+        if (flashlightInstance != null)
+        {
+            UpdateFlashlightTransform();
+        }
+    }
+
+    void Toggle()
+    {
+        if (flashlightInstance == null)
+        {
+            SpawnInstance();
+        }
+        else
+        {
+            ShutdownInstance();
+        }
+    }
+
+    void SpawnInstance()
+    {
+        if (flashlightPrefab == null)
+        {
+            Debug.LogWarning("Flashlight prefabı atanmamış.", this);
+            return;
+        }
+
+        Transform parent = (!followCursorPosition && flashlightSocket != null) ? flashlightSocket : null;
+        GameObject created = parent ? Instantiate(flashlightPrefab, parent) : Instantiate(flashlightPrefab);
+        flashlightInstance = created.transform;
+
+        Vector3 spawnPosition = GetPivotPosition();
+        flashlightInstance.position = new Vector3(spawnPosition.x, spawnPosition.y, zDepth);
+        UpdateFlashlightRotation(GetMouseWorldPosition(spawnPosition));
+    }
+
+    void UpdateFlashlightTransform()
+    {
+        Vector3 pivotPosition = GetPivotPosition();
+        Vector3 mouseWorld = GetMouseWorldPosition(pivotPosition);
+
+        if (followCursorPosition)
+        {
+            Vector2 ownerPosition = transform.position;
+            Vector2 desired = new(mouseWorld.x, mouseWorld.y);
+            Vector2 clamped = ClampToCircle(desired, ownerPosition, maxDistance);
+            flashlightInstance.position = new Vector3(clamped.x, clamped.y, zDepth);
+        }
+        else
+        {
+            flashlightInstance.position = new Vector3(pivotPosition.x, pivotPosition.y, zDepth);
+        }
+
+        UpdateFlashlightRotation(mouseWorld);
+    }
+
+    void UpdateFlashlightRotation(Vector3 targetWorld)
+    {
+        Vector3 origin = flashlightInstance != null ? flashlightInstance.position : GetPivotPosition();
+        Vector2 direction = new(targetWorld.x - origin.x, targetWorld.y - origin.y);
+
+        if (direction.sqrMagnitude <= 0.0001f)
+        {
+            return;
+        }
+
+        float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+        flashlightInstance.rotation = Quaternion.Euler(0f, 0f, angle);
+    }
+
+    void ShutdownInstance()
+    {
+        if (flashlightInstance == null)
+        {
+            return;
+        }
+
+        Destroy(flashlightInstance.gameObject);
+        flashlightInstance = null;
+    }
+
+    bool HasControlAuthority()
+    {
+        if (controlGate != null)
+        {
+            return controlGate.IsCharacterActive(gameObject);
+        }
+
+        return true;
+    }
+
+    void CacheControlGate()
+    {
+        controlGate = null;
+
+        if (activeControlProvider == null)
+        {
+            warnedInvalidProvider = false;
+            return;
+        }
+
+        controlGate = activeControlProvider as IActiveCharacterGate;
+
+        if (controlGate == null)
+        {
+            if (!warnedInvalidProvider)
+            {
+                Debug.LogWarning($"{activeControlProvider.name} bileşeni IActiveCharacterGate arayüzünü uygulamıyor.", this);
+                warnedInvalidProvider = true;
+            }
+        }
+        else
+        {
+            warnedInvalidProvider = false;
+        }
+    }
+
+    Vector3 GetPivotPosition()
+    {
+        if (flashlightSocket != null)
+        {
+            Vector3 socketPosition = flashlightSocket.position;
+            socketPosition.z = zDepth;
+            return socketPosition;
+        }
+
+        Vector3 ownerPosition = transform.position;
+        ownerPosition.x += spawnOffset.x;
+        ownerPosition.y += spawnOffset.y;
+        ownerPosition.z = zDepth;
+        return ownerPosition;
+    }
+
+    Vector3 GetMouseWorldPosition(Vector3 fallback)
+    {
+        Camera cam = ResolveCamera();
+        Mouse mouse = ResolveMouse();
+
+        if (cam == null || mouse == null)
+        {
+            return fallback;
+        }
+
+        Vector2 mousePos = mouse.position.ReadValue();
+        float planeDistance = Mathf.Abs(cam.transform.position.z - zDepth);
+        Vector3 screenPoint = new(mousePos.x, mousePos.y, planeDistance);
+        Vector3 world = cam.ScreenToWorldPoint(screenPoint);
+        world.z = zDepth;
+        return world;
+    }
+
+    Camera ResolveCamera()
+    {
+        if (cachedCamera == null)
+        {
+            cachedCamera = Camera.main;
+        }
+
+        return cachedCamera;
+    }
+
+    Mouse ResolveMouse()
+    {
+        if (cachedMouse == null || !cachedMouse.added)
+        {
+            cachedMouse = Mouse.current;
+        }
+
+        return cachedMouse;
+    }
+
+    static Vector2 ClampToCircle(Vector2 point, Vector2 center, float radius)
+    {
+        if (radius <= 0f)
+        {
+            return center;
+        }
+
+        Vector2 offset = point - center;
+        float sqrRadius = radius * radius;
+
+        if (offset.sqrMagnitude > sqrRadius)
+        {
+            offset = offset.normalized * radius;
+            return center + offset;
+        }
+
+        return point;
+    }
+}

--- a/Assets/scripts/InputAdapter.cs
+++ b/Assets/scripts/InputAdapter.cs
@@ -2,30 +2,45 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 [DisallowMultipleComponent]
+[DefaultExecutionOrder(-200)]
 public class InputAdapter : MonoBehaviour
 {
     [Header("Input Actions")]
-    public InputActionReference move;     // Vector2
-    public InputActionReference jump;     // Button
-    public InputActionReference interact; // Button (optional)
+    public InputActionReference move;             // Vector2
+    public InputActionReference jump;             // Button
+    public InputActionReference interact;         // Button (optional)
+    public InputActionReference flashlightToggle; // Button
 
     public float MoveX { get; private set; }
     public float MoveY { get; private set; }
     public bool  JumpHeld { get; private set; }
     public bool  JumpPressed { get; private set; }
     public bool  InteractPressed { get; private set; }
+    public bool  FlashlightTogglePressed { get; private set; }
 
     void OnEnable()
     {
         move?.action?.Enable();
         jump?.action?.Enable();
         interact?.action?.Enable();
+        flashlightToggle?.action?.Enable();
     }
     void OnDisable()
     {
         move?.action?.Disable();
         jump?.action?.Disable();
         interact?.action?.Disable();
+        flashlightToggle?.action?.Disable();
+    }
+
+    void Update()
+    {
+        Collect();
+    }
+
+    void LateUpdate()
+    {
+        ClearFrameEdges();
     }
 
     public void Collect()
@@ -36,11 +51,13 @@ public class InputAdapter : MonoBehaviour
         JumpHeld = jump && jump.action.IsPressed();
         JumpPressed = jump && jump.action.WasPressedThisFrame();
         InteractPressed = interact && interact.action.WasPressedThisFrame();
+        FlashlightTogglePressed = flashlightToggle && flashlightToggle.action.WasPressedThisFrame();
     }
 
     public void ClearFrameEdges()
     {
         JumpPressed = false;
         InteractPressed = false;
+        FlashlightTogglePressed = false;
     }
 }

--- a/Assets/scripts/PlayerOrchestrator.cs
+++ b/Assets/scripts/PlayerOrchestrator.cs
@@ -20,10 +20,8 @@ public class PlayerOrchestrator : MonoBehaviour
 
     void Update()
     {
-        input?.Collect();
         sensors?.Sample();
         abilities?.Tick(Time.deltaTime);
-        input?.ClearFrameEdges();
     }
 
     void FixedUpdate() => motor?.PhysicsStep(Time.fixedDeltaTime);


### PR DESCRIPTION
## Summary
- ensure the input adapter owns its own collect/clear lifecycle so late-updating systems can read toggle presses
- rely on player orchestrator only for sensors and ability ticking now that input adapter has a defined execution order

## Testing
- not run (Unity editor feature)


------
https://chatgpt.com/codex/tasks/task_e_68d5894b135083229e9513cf192c0ad4