### PR TITLE
Add character split/merge switching system with ability gating

### DIFF
--- a/Assets/Scripts/Items/FlashlightController.cs
+++ b/Assets/Scripts/Items/FlashlightController.cs
@@ -1,0 +1,288 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[DisallowMultipleComponent]
+public class FlashlightController : MonoBehaviour
+{
+    [Header("Fener Kurulumu")]
+    [Tooltip("F tuşuyla üretilecek fener prefabı.")]
+    [SerializeField] GameObject flashlightPrefab;
+
+    [Tooltip("Fenerin varsayılan olarak bağlanacağı soket (isteğe bağlı).")]
+    [SerializeField] Transform flashlightSocket;
+
+    [Tooltip("Soket atanmadığında karakter pozisyonuna uygulanacak ofset.")]
+    [SerializeField] Vector2 spawnOffset = new(0.25f, 0.45f);
+
+    [Header("Davranış")]
+    [Tooltip("Açıksa fener fare konumuna taşınır, kapalıysa pivotta kalarak yalnızca döner.")]
+    [SerializeField] bool followCursorPosition = false;
+
+    [Tooltip("Takip modunda fenerin oyuncudan uzaklaşabileceği azami mesafe (dünya birimi).")]
+    [SerializeField] float maxDistance = 6f;
+
+    [Tooltip("Fener örneğinin Z ekseninde tutulacağı sabit değer.")]
+    [SerializeField] float zDepth = 0f;
+
+    [Tooltip("Fener yalnızca karakter aktif kontrol altındayken açılabilsin mi?")]
+    [SerializeField] bool onlyWhenActiveControlled = true;
+
+    [Tooltip("Time.timeScale ≤ 0 olduğunda güncelleme döngüsü çalıştırılmaz.")]
+    [SerializeField] bool respectPauseState = true;
+
+    [Tooltip("Aktif karakter bilgisini sağlayan PartyController/InputRouter benzeri bileşen (isteğe bağlı).")]
+    [SerializeField] MonoBehaviour activeControlProvider;
+
+    InputAdapter input;
+    Camera cachedCamera;
+    Mouse cachedMouse;
+    Transform flashlightInstance;
+    IActiveCharacterGate controlGate;
+    bool warnedInvalidProvider;
+
+    public interface IActiveCharacterGate
+    {
+        bool IsCharacterActive(GameObject character);
+    }
+
+    void Awake()
+    {
+        input = GetComponent<InputAdapter>();
+        cachedCamera = Camera.main;
+        cachedMouse = Mouse.current;
+        CacheControlGate();
+    }
+
+    void OnEnable()
+    {
+        if (cachedCamera == null)
+        {
+            cachedCamera = Camera.main;
+        }
+
+        if (cachedMouse == null)
+        {
+            cachedMouse = Mouse.current;
+        }
+    }
+
+    void OnValidate() => CacheControlGate();
+
+    void OnDisable() => ShutdownInstance();
+
+    void OnDestroy() => ShutdownInstance();
+
+    void Update()
+    {
+        if (respectPauseState && Time.timeScale <= 0f)
+        {
+            return;
+        }
+
+        if (input == null)
+        {
+            return;
+        }
+
+        bool hasControl = !onlyWhenActiveControlled || HasControlAuthority();
+
+        if (input.FlashlightTogglePressed && hasControl)
+        {
+            Toggle();
+        }
+
+        if (!hasControl && flashlightInstance != null)
+        {
+            ShutdownInstance();
+            return;
+        }
+
+        if (flashlightInstance != null)
+        {
+            UpdateFlashlightTransform();
+        }
+    }
+
+    void Toggle()
+    {
+        if (flashlightInstance == null)
+        {
+            SpawnInstance();
+        }
+        else
+        {
+            ShutdownInstance();
+        }
+    }
+
+    void SpawnInstance()
+    {
+        if (flashlightPrefab == null)
+        {
+            Debug.LogWarning("Flashlight prefabı atanmamış.", this);
+            return;
+        }
+
+        Transform parent = (!followCursorPosition && flashlightSocket != null) ? flashlightSocket : null;
+        GameObject created = parent ? Instantiate(flashlightPrefab, parent) : Instantiate(flashlightPrefab);
+        flashlightInstance = created.transform;
+
+        Vector3 spawnPosition = GetPivotPosition();
+        flashlightInstance.position = new Vector3(spawnPosition.x, spawnPosition.y, zDepth);
+        UpdateFlashlightRotation(GetMouseWorldPosition(spawnPosition));
+    }
+
+    void UpdateFlashlightTransform()
+    {
+        Vector3 pivotPosition = GetPivotPosition();
+        Vector3 mouseWorld = GetMouseWorldPosition(pivotPosition);
+
+        if (followCursorPosition)
+        {
+            Vector2 ownerPosition = transform.position;
+            Vector2 desired = new(mouseWorld.x, mouseWorld.y);
+            Vector2 clamped = ClampToCircle(desired, ownerPosition, maxDistance);
+            flashlightInstance.position = new Vector3(clamped.x, clamped.y, zDepth);
+        }
+        else
+        {
+            flashlightInstance.position = new Vector3(pivotPosition.x, pivotPosition.y, zDepth);
+        }
+
+        UpdateFlashlightRotation(mouseWorld);
+    }
+
+    void UpdateFlashlightRotation(Vector3 targetWorld)
+    {
+        Vector3 origin = flashlightInstance != null ? flashlightInstance.position : GetPivotPosition();
+        Vector2 direction = new(targetWorld.x - origin.x, targetWorld.y - origin.y);
+
+        if (direction.sqrMagnitude <= 0.0001f)
+        {
+            return;
+        }
+
+        float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+        flashlightInstance.rotation = Quaternion.Euler(0f, 0f, angle);
+    }
+
+    void ShutdownInstance()
+    {
+        if (flashlightInstance == null)
+        {
+            return;
+        }
+
+        Destroy(flashlightInstance.gameObject);
+        flashlightInstance = null;
+    }
+
+    bool HasControlAuthority()
+    {
+        if (controlGate != null)
+        {
+            return controlGate.IsCharacterActive(gameObject);
+        }
+
+        return true;
+    }
+
+    void CacheControlGate()
+    {
+        controlGate = null;
+
+        if (activeControlProvider == null)
+        {
+            warnedInvalidProvider = false;
+            return;
+        }
+
+        controlGate = activeControlProvider as IActiveCharacterGate;
+
+        if (controlGate == null)
+        {
+            if (!warnedInvalidProvider)
+            {
+                Debug.LogWarning($"{activeControlProvider.name} bileşeni IActiveCharacterGate arayüzünü uygulamıyor.", this);
+                warnedInvalidProvider = true;
+            }
+        }
+        else
+        {
+            warnedInvalidProvider = false;
+        }
+    }
+
+    Vector3 GetPivotPosition()
+    {
+        if (flashlightSocket != null)
+        {
+            Vector3 socketPosition = flashlightSocket.position;
+            socketPosition.z = zDepth;
+            return socketPosition;
+        }
+
+        Vector3 ownerPosition = transform.position;
+        ownerPosition.x += spawnOffset.x;
+        ownerPosition.y += spawnOffset.y;
+        ownerPosition.z = zDepth;
+        return ownerPosition;
+    }
+
+    Vector3 GetMouseWorldPosition(Vector3 fallback)
+    {
+        Camera cam = ResolveCamera();
+        Mouse mouse = ResolveMouse();
+
+        if (cam == null || mouse == null)
+        {
+            return fallback;
+        }
+
+        Vector2 mousePos = mouse.position.ReadValue();
+        float planeDistance = Mathf.Abs(cam.transform.position.z - zDepth);
+        Vector3 screenPoint = new(mousePos.x, mousePos.y, planeDistance);
+        Vector3 world = cam.ScreenToWorldPoint(screenPoint);
+        world.z = zDepth;
+        return world;
+    }
+
+    Camera ResolveCamera()
+    {
+        if (cachedCamera == null)
+        {
+            cachedCamera = Camera.main;
+        }
+
+        return cachedCamera;
+    }
+
+    Mouse ResolveMouse()
+    {
+        if (cachedMouse == null || !cachedMouse.added)
+        {
+            cachedMouse = Mouse.current;
+        }
+
+        return cachedMouse;
+    }
+
+    static Vector2 ClampToCircle(Vector2 point, Vector2 center, float radius)
+    {
+        if (radius <= 0f)
+        {
+            return center;
+        }
+
+        Vector2 offset = point - center;
+        float sqrRadius = radius * radius;
+
+        if (offset.sqrMagnitude > sqrRadius)
+        {
+            offset = offset.normalized * radius;
+            return center + offset;
+        }
+
+        return point;
+    }
+}

--- a/Assets/scripts/AbilityRuntime.cs
+++ b/Assets/scripts/AbilityRuntime.cs
@@ -1,0 +1,129 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class AbilityRuntime : MonoBehaviour
+{
+    [System.Serializable]
+    struct AbilitySnapshot
+    {
+        public bool canJump;
+        public bool canWallJump;
+        public bool canClimb;
+        public bool canSupplyPower;
+        public bool canUsePanels;
+        public bool canRepair;
+        public bool canMerge;
+        public bool canSwitchCharacter;
+    }
+
+    [Header("Başlangıç Seti")]
+    [Tooltip("Oyun başında uygulanacak AbilitySet referansı.")]
+    [SerializeField] AbilitySet initialAbilitySet;
+
+    [Tooltip("Awake sırasında initialAbilitySet otomatik olarak uygulanır.")]
+    [SerializeField] bool applyInitialOnAwake = true;
+
+    [Tooltip("Set değişimleri konsola loglansın mı?")]
+    [SerializeField] bool logChanges = false;
+
+    [Header("Anlık Durum (salt okunur)")]
+    [SerializeField] AbilitySnapshot runtimeFlags;
+
+    AbilitySet currentSet;
+
+    void Awake()
+    {
+        if (applyInitialOnAwake)
+        {
+            ApplyAbilitySet(initialAbilitySet, silent: true);
+        }
+        else if (currentSet == null)
+        {
+            ResetToDefaults();
+        }
+    }
+
+    void OnValidate()
+    {
+#if UNITY_EDITOR
+        if (!Application.isPlaying)
+        {
+            if (initialAbilitySet)
+                ApplyAbilitySet(initialAbilitySet, silent: true);
+            else
+                ResetToDefaults();
+        }
+#endif
+    }
+
+    public AbilitySet CurrentSet => currentSet;
+
+    public bool CanJump            => runtimeFlags.canJump;
+    public bool CanWallJump        => runtimeFlags.canWallJump;
+    public bool CanClimb           => runtimeFlags.canClimb;
+    public bool CanSupplyPower     => runtimeFlags.canSupplyPower;
+    public bool CanUsePanels       => runtimeFlags.canUsePanels;
+    public bool CanRepair          => runtimeFlags.canRepair;
+    public bool CanMerge           => runtimeFlags.canMerge;
+    public bool CanSwitchCharacter => runtimeFlags.canSwitchCharacter;
+    public bool CanInteract        => runtimeFlags.canUsePanels || runtimeFlags.canSupplyPower || runtimeFlags.canRepair;
+
+    public void ApplyAbilitySet(AbilitySet set) => ApplyAbilitySet(set, silent: false);
+
+    public void ApplyAbilitySet(AbilitySet set, bool silent)
+    {
+        currentSet = set;
+
+        if (set)
+        {
+            runtimeFlags.canJump = set.canJump;
+            runtimeFlags.canWallJump = set.canWallJump;
+            runtimeFlags.canClimb = set.canClimb;
+            runtimeFlags.canSupplyPower = set.canSupplyPower;
+            runtimeFlags.canUsePanels = set.canUsePanels;
+            runtimeFlags.canRepair = set.canRepair;
+            runtimeFlags.canMerge = set.canMerge;
+            runtimeFlags.canSwitchCharacter = set.canSwitchCharacter;
+        }
+        else
+        {
+            ResetToDefaults();
+        }
+
+        if (logChanges && !silent)
+        {
+            Debug.Log($"[AbilityRuntime] {name} set -> {(set ? set.name : "(default)")}", this);
+        }
+    }
+
+    public void OverrideFlags(bool canJump, bool canWallJump, bool canClimb,
+        bool canSupplyPower, bool canUsePanels, bool canRepair, bool canMerge, bool canSwitchCharacter)
+    {
+        runtimeFlags.canJump = canJump;
+        runtimeFlags.canWallJump = canWallJump;
+        runtimeFlags.canClimb = canClimb;
+        runtimeFlags.canSupplyPower = canSupplyPower;
+        runtimeFlags.canUsePanels = canUsePanels;
+        runtimeFlags.canRepair = canRepair;
+        runtimeFlags.canMerge = canMerge;
+        runtimeFlags.canSwitchCharacter = canSwitchCharacter;
+        currentSet = null;
+
+        if (logChanges)
+        {
+            Debug.Log($"[AbilityRuntime] {name} flags override", this);
+        }
+    }
+
+    public void ResetToDefaults()
+    {
+        runtimeFlags.canJump = true;
+        runtimeFlags.canWallJump = true;
+        runtimeFlags.canClimb = true;
+        runtimeFlags.canSupplyPower = true;
+        runtimeFlags.canUsePanels = true;
+        runtimeFlags.canRepair = true;
+        runtimeFlags.canMerge = true;
+        runtimeFlags.canSwitchCharacter = true;
+    }
+}

--- a/Assets/scripts/AbilitySet.cs
+++ b/Assets/scripts/AbilitySet.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Abilities/Ability Set", fileName = "AbilitySet")]
+public class AbilitySet : ScriptableObject
+{
+    [Header("Hareket")]
+    [Tooltip("Karakter zıplayabilir mi?")]
+    public bool canJump = true;
+
+    [Tooltip("Karakter duvar zıplaması yapabilir mi?")]
+    public bool canWallJump = true;
+
+    [Tooltip("Karakter merdiven ve tırmanılabilir yüzeyleri kullanabilir mi?")]
+    public bool canClimb = true;
+
+    [Header("Sim'e Özel / Yardımcı")]
+    [Tooltip("Sim enerji beslemesi yapabilir mi?")]
+    public bool canSupplyPower = true;
+
+    [Tooltip("Sim panelleri kullanabilir veya terminalleri açabilir mi?")]
+    public bool canUsePanels = true;
+
+    [Tooltip("Sim onarım aksiyonlarını tetikleyebilir mi?")]
+    public bool canRepair = true;
+
+    [Header("Koordinasyon")]
+    [Tooltip("Karakter merge/split akışını tetikleyebilir mi?")]
+    public bool canMerge = true;
+
+    [Tooltip("Karakter aktif kontrolü diğer ajana devredebilir mi?")]
+    public bool canSwitchCharacter = true;
+}

--- a/Assets/scripts/CharacterSwitcher.cs
+++ b/Assets/scripts/CharacterSwitcher.cs
@@ -1,0 +1,448 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class CharacterSwitcher : MonoBehaviour, FlashlightController.IActiveCharacterGate
+{
+    public enum AgentState
+    {
+        Merged,
+        Elior,
+        Sim
+    }
+
+    [Header("Ajan Referansları")]
+    [Tooltip("Elior'un kök GameObject'i. Boş bırakılırsa bu nesne kullanılır.")]
+    [SerializeField] GameObject eliorRoot;
+
+    [Tooltip("Sim'in kök GameObject'i.")]
+    [SerializeField] GameObject simRoot;
+
+    [Tooltip("Elior sensör bileşeni (yer kontrolü için).")]
+    [SerializeField] Sensors2D eliorSensors;
+
+    [Tooltip("Sim sensör bileşeni (yer kontrolü için).")]
+    [SerializeField] Sensors2D simSensors;
+
+    [Tooltip("Elior'un AbilityRuntime bileşeni.")]
+    [SerializeField] AbilityRuntime eliorAbilities;
+
+    [Tooltip("Sim'in AbilityRuntime bileşeni.")]
+    [SerializeField] AbilityRuntime simAbilities;
+
+    [Tooltip("Merge/Split işlemini yönetecek MergeController.")]
+    [SerializeField] MergeController mergeController;
+
+    [Tooltip("Girişleri okuyacak InputAdapter (boşsa aynı nesneden alınır).")]
+    [SerializeField] InputAdapter input;
+
+    [Header("Başlangıç Durumu")]
+    [Tooltip("Sahne yüklendiğinde hangi ajan aktif sayılacak?")]
+    [SerializeField] AgentState initialAgentState = AgentState.Merged;
+
+    [Header("Yetenek Setleri")]
+    [Tooltip("Merged modda Elior için uygulanacak yetenek seti.")]
+    [SerializeField] AbilitySet mergedEliorAbilities;
+
+    [Tooltip("Merged modda Sim için uygulanacak yetenek seti (boşsa paneller/güç kapatılır).")]
+    [SerializeField] AbilitySet mergedSimAbilities;
+
+    [Tooltip("Split modda Elior için uygulanacak yetenek seti.")]
+    [SerializeField] AbilitySet splitEliorAbilities;
+
+    [Tooltip("Split modda Sim için uygulanacak yetenek seti.")]
+    [SerializeField] AbilitySet splitSimAbilities;
+
+    [Header("Switch Ayarları")]
+    [Tooltip("Karakter değişiminde uygulanacak cooldown süresi (saniye).")]
+    [SerializeField] float switchCooldownSeconds = 0.35f;
+
+    [Tooltip("Switch yalnızca yerdeyken çalışsın mı?")]
+    [SerializeField] bool requireGroundedForSwitch = true;
+
+    [Tooltip("Merge/Split yalnızca yere basarken tetiklensin mi?")]
+    [SerializeField] bool requireGroundedForMergeToggle = true;
+
+    [Tooltip("Split tamamlandığında varsayılan aktif ajan Sim olsun mu?")]
+    [SerializeField] bool preferSimAfterSplit = true;
+
+    [Tooltip("Time.timeScale <= 0 olduğunda girişleri yok say.")]
+    [SerializeField] bool respectPauseState = true;
+
+    [Header("Input Shim (opsiyonel)")]
+    [Tooltip("InputAdapter aksiyonları tanımlı değilse harici tuş okumasını açar.")]
+    [SerializeField] bool useInputShim = false;
+
+    [Tooltip("InputShim açıkken ajan değişim tuşu.")]
+    [SerializeField] KeyCode switchKey = KeyCode.Q;
+
+    [Tooltip("InputShim açıkken merge toggle tuşu.")]
+    [SerializeField] KeyCode mergeKey = KeyCode.R;
+
+    [Header("Debug")]
+    [Tooltip("TransitionLock aktifken ekranda bilgilendirici yazı göster.")]
+    [SerializeField] bool showTransitionLabel = true;
+
+    [Tooltip("Merge sırasında gösterilecek yazı.")]
+    [SerializeField] string mergingLabel = "Merging...";
+
+    [Tooltip("Split sırasında gösterilecek yazı.")]
+    [SerializeField] string splittingLabel = "Splitting...";
+
+    [Tooltip("OnGUI etiketi ekran pozisyonu.")]
+    [SerializeField] Vector2 labelScreenPosition = new(20f, 20f);
+
+    [Tooltip("OnGUI etiketi rengi.")]
+    [SerializeField] Color labelColor = Color.white;
+
+    [Tooltip("Durum değişimleri ve akışlar konsola loglansın mı?")]
+    [SerializeField] bool logTransitions = true;
+
+    public AgentState ActiveAgent => activeAgent;
+    public bool TransitionLock => transitionLock;
+    public bool IsSplit => activeAgent != AgentState.Merged;
+
+    public event System.Action<AgentState> ActiveAgentChanged;
+
+    AgentState activeAgent;
+    AgentState pendingAgent;
+    float switchCooldownTimer;
+    bool transitionLock;
+    string currentTransitionLabel;
+    bool warnedMissingMergedSimSet;
+    bool warnedMissingSplitSimSet;
+
+    void Awake()
+    {
+        if (!eliorRoot)
+            eliorRoot = gameObject;
+
+        input ??= GetComponent<InputAdapter>();
+        mergeController ??= GetComponent<MergeController>();
+        eliorSensors ??= eliorRoot ? eliorRoot.GetComponent<Sensors2D>() : null;
+        simSensors ??= simRoot ? simRoot.GetComponent<Sensors2D>() : null;
+        eliorAbilities ??= eliorRoot ? eliorRoot.GetComponent<AbilityRuntime>() : null;
+        simAbilities ??= simRoot ? simRoot.GetComponent<AbilityRuntime>() : null;
+
+        activeAgent = initialAgentState;
+        pendingAgent = activeAgent;
+
+        if (mergeController)
+        {
+            mergeController.RegisterSwitcher(this);
+        }
+
+        ApplyAbilityConfiguration(activeAgent, silent: true);
+    }
+
+    void Update()
+    {
+        if (respectPauseState && Time.timeScale <= 0f)
+        {
+            return;
+        }
+
+        if (switchCooldownTimer > 0f)
+        {
+            switchCooldownTimer = Mathf.Max(0f, switchCooldownTimer - Time.deltaTime);
+        }
+
+        bool switchPressed = input && input.SwitchCharacterPressed;
+        bool mergePressed = input && input.MergeTogglePressed;
+
+        if (useInputShim)
+        {
+            switchPressed |= Input.GetKeyDown(switchKey);
+            mergePressed  |= Input.GetKeyDown(mergeKey);
+        }
+
+        if (mergePressed)
+        {
+            HandleMergeToggle();
+        }
+        else if (switchPressed)
+        {
+            HandleSwitchRequest();
+        }
+    }
+
+    void HandleSwitchRequest()
+    {
+        if (!IsSplit)
+            return;
+
+        if (transitionLock)
+            return;
+
+        if (switchCooldownTimer > 0f)
+            return;
+
+        var abilities = GetAbilitiesForAgent(activeAgent);
+        if (abilities && !abilities.CanSwitchCharacter)
+            return;
+
+        if (requireGroundedForSwitch && !IsGrounded(activeAgent))
+            return;
+
+        AgentState target = activeAgent == AgentState.Elior ? AgentState.Sim : AgentState.Elior;
+        SetActiveAgentInternal(target, raiseEvent: true);
+        switchCooldownTimer = switchCooldownSeconds;
+
+        if (logTransitions)
+        {
+            Debug.Log($"[CharacterSwitcher] Switch -> {target}", this);
+        }
+    }
+
+    void HandleMergeToggle()
+    {
+        if (transitionLock)
+            return;
+
+        bool wantSplit = activeAgent == AgentState.Merged;
+
+        if (!HasMergePermission(wantSplit))
+            return;
+
+        if (requireGroundedForMergeToggle && !GroundRequirementSatisfied(wantSplit))
+            return;
+
+        if (!mergeController)
+            return;
+
+        if (wantSplit)
+        {
+            AgentState target = preferSimAfterSplit ? AgentState.Sim : AgentState.Elior;
+            if (mergeController.BeginSplit())
+            {
+                BeginTransition(target, splittingLabel);
+                if (logTransitions)
+                    Debug.Log("[CharacterSwitcher] Split started", this);
+            }
+        }
+        else
+        {
+            if (mergeController.BeginMerge())
+            {
+                BeginTransition(AgentState.Merged, mergingLabel);
+                if (logTransitions)
+                    Debug.Log("[CharacterSwitcher] Merge started", this);
+            }
+        }
+    }
+
+    void BeginTransition(AgentState target, string label)
+    {
+        pendingAgent = target;
+        SetTransitionLock(true, label);
+    }
+
+    public void SetTransitionLock(bool locked, string label = null)
+    {
+        transitionLock = locked;
+        currentTransitionLabel = locked ? label : null;
+        if (!locked)
+        {
+            switchCooldownTimer = 0f;
+        }
+    }
+
+    void SetActiveAgentInternal(AgentState newState, bool raiseEvent)
+    {
+        if (activeAgent == newState)
+            return;
+
+        activeAgent = newState;
+        ApplyAbilityConfiguration(activeAgent, silent: !logTransitions);
+        pendingAgent = activeAgent;
+
+        if (raiseEvent)
+            ActiveAgentChanged?.Invoke(activeAgent);
+    }
+
+    bool HasMergePermission(bool wantSplit)
+    {
+        if (wantSplit)
+        {
+            var abilities = eliorAbilities;
+            if (abilities && !abilities.CanMerge)
+                return false;
+        }
+        else
+        {
+            bool eliorOk = !eliorAbilities || eliorAbilities.CanMerge;
+            bool simOk   = !simAbilities   || simAbilities.CanMerge;
+            if (!eliorOk || !simOk)
+                return false;
+        }
+
+        return true;
+    }
+
+    bool GroundRequirementSatisfied(bool wantSplit)
+    {
+        if (!requireGroundedForMergeToggle)
+            return true;
+
+        if (wantSplit)
+            return IsGrounded(AgentState.Elior);
+
+        bool eliorGround = !eliorSensors || eliorSensors.isGrounded;
+        bool simGround   = !simSensors   || simSensors.isGrounded;
+        return eliorGround && simGround;
+    }
+
+    bool IsGrounded(AgentState agent)
+    {
+        Sensors2D sensor = agent == AgentState.Sim ? simSensors : eliorSensors;
+        return !sensor || sensor.isGrounded;
+    }
+
+    AbilityRuntime GetAbilitiesForAgent(AgentState agent)
+    {
+        return agent == AgentState.Sim ? simAbilities : eliorAbilities;
+    }
+
+    void ApplyAbilityConfiguration(AgentState state, bool silent)
+    {
+        switch (state)
+        {
+            case AgentState.Merged:
+                ApplyAbilitySet(eliorAbilities, mergedEliorAbilities, splitEliorAbilities, silent);
+                ApplyMergedSimAbilities(silent);
+                break;
+            case AgentState.Elior:
+            case AgentState.Sim:
+                ApplyAbilitySet(eliorAbilities, splitEliorAbilities, mergedEliorAbilities, silent);
+                ApplyAbilitySet(simAbilities, splitSimAbilities, mergedSimAbilities, silent);
+                break;
+        }
+    }
+
+    void ApplyAbilitySet(AbilityRuntime runtime, AbilitySet preferred, AbilitySet fallback, bool silent)
+    {
+        if (!runtime)
+            return;
+
+        if (preferred)
+        {
+            runtime.ApplyAbilitySet(preferred, silent);
+            return;
+        }
+
+        if (fallback)
+        {
+            runtime.ApplyAbilitySet(fallback, silent);
+            return;
+        }
+
+        runtime.ApplyAbilitySet(null, silent);
+    }
+
+    void ApplyMergedSimAbilities(bool silent)
+    {
+        if (!simAbilities)
+            return;
+
+        if (mergedSimAbilities)
+        {
+            simAbilities.ApplyAbilitySet(mergedSimAbilities, silent);
+            return;
+        }
+
+        if (!splitSimAbilities)
+        {
+            if (!warnedMissingSplitSimSet && logTransitions && !silent)
+            {
+                Debug.LogWarning("[CharacterSwitcher] splitSimAbilities atanmadı; varsayılan yeteneklerle devam ediliyor.", this);
+                warnedMissingSplitSimSet = true;
+            }
+
+            simAbilities.ResetToDefaults();
+            simAbilities.OverrideFlags(true, true, true, false, false, simAbilities.CanRepair, simAbilities.CanMerge, simAbilities.CanSwitchCharacter);
+            return;
+        }
+
+        simAbilities.ApplyAbilitySet(splitSimAbilities, true);
+
+        bool jump = simAbilities.CanJump;
+        bool wallJump = simAbilities.CanWallJump;
+        bool climb = simAbilities.CanClimb;
+        bool repair = simAbilities.CanRepair;
+        bool merge = simAbilities.CanMerge;
+        bool switchChar = simAbilities.CanSwitchCharacter;
+
+        simAbilities.OverrideFlags(jump, wallJump, climb, false, false, repair, merge, switchChar);
+
+        if (!warnedMissingMergedSimSet && logTransitions && !silent)
+        {
+            Debug.LogWarning("[CharacterSwitcher] mergedSimAbilities atanmadı; Split setinden türetilip Sim'e özel yetenekler kapatıldı.", this);
+            warnedMissingMergedSimSet = true;
+        }
+    }
+
+    internal void NotifyTransitionCompleted(MergeController.TransitionKind kind)
+    {
+        switch (kind)
+        {
+            case MergeController.TransitionKind.Merge:
+                SetActiveAgentInternal(AgentState.Merged, raiseEvent: true);
+                if (logTransitions)
+                    Debug.Log("[CharacterSwitcher] Merge completed", this);
+                break;
+            case MergeController.TransitionKind.Split:
+                AgentState resolved = pendingAgent;
+                if (resolved == AgentState.Merged)
+                    resolved = preferSimAfterSplit ? AgentState.Sim : AgentState.Elior;
+                SetActiveAgentInternal(resolved, raiseEvent: true);
+                if (logTransitions)
+                    Debug.Log($"[CharacterSwitcher] Split completed -> {resolved}", this);
+                break;
+        }
+
+        SetTransitionLock(false);
+    }
+
+    internal void NotifyTransitionCancelled()
+    {
+        SetTransitionLock(false);
+    }
+
+    void OnGUI()
+    {
+        if (!showTransitionLabel || !transitionLock)
+            return;
+
+        if (string.IsNullOrEmpty(currentTransitionLabel))
+            return;
+
+        Color prev = GUI.color;
+        GUI.color = labelColor;
+        GUI.Label(new Rect(labelScreenPosition.x, labelScreenPosition.y, 200f, 24f), currentTransitionLabel);
+        GUI.color = prev;
+    }
+
+    public bool IsCharacterActive(GameObject character)
+    {
+        if (!character)
+            return false;
+
+        if (activeAgent == AgentState.Merged)
+            return IsTarget(character, eliorRoot);
+
+        if (activeAgent == AgentState.Elior)
+            return IsTarget(character, eliorRoot);
+
+        return IsTarget(character, simRoot);
+    }
+
+    bool IsTarget(GameObject candidate, GameObject root)
+    {
+        if (!candidate || !root)
+            return false;
+
+        if (candidate == root)
+            return true;
+
+        return candidate.transform.IsChildOf(root.transform);
+    }
+}

--- a/Assets/scripts/ClimbController.cs
+++ b/Assets/scripts/ClimbController.cs
@@ -8,6 +8,7 @@ public class ClimbController : MonoBehaviour
     Sensors2D sensors;
     LocomotionMotor2D motor;
     PlayerStateMachine fsm;
+    AbilityRuntime abilities;
 
     void Awake()
     {
@@ -15,10 +16,14 @@ public class ClimbController : MonoBehaviour
         sensors= GetComponent<Sensors2D>();
         motor  = GetComponent<LocomotionMotor2D>();
         fsm    = GetComponent<PlayerStateMachine>();
+        abilities = GetComponent<AbilityRuntime>();
     }
 
     public void Tick(float dt)
     {
+        if (abilities && !abilities.CanClimb)
+            return;
+
         // Climb aktifken kontroller
         if (fsm.Current == PlayerStateMachine.LocoState.Climb)
         {

--- a/Assets/scripts/InputAdapter.cs
+++ b/Assets/scripts/InputAdapter.cs
@@ -2,30 +2,53 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 [DisallowMultipleComponent]
+[DefaultExecutionOrder(-200)]
 public class InputAdapter : MonoBehaviour
 {
     [Header("Input Actions")]
-    public InputActionReference move;     // Vector2
-    public InputActionReference jump;     // Button
-    public InputActionReference interact; // Button (optional)
+    public InputActionReference move;             // Vector2
+    public InputActionReference jump;             // Button
+    public InputActionReference interact;         // Button (optional)
+    public InputActionReference flashlightToggle; // Button
+    public InputActionReference switchCharacter;  // Button
+    public InputActionReference mergeToggle;      // Button
 
     public float MoveX { get; private set; }
     public float MoveY { get; private set; }
     public bool  JumpHeld { get; private set; }
     public bool  JumpPressed { get; private set; }
     public bool  InteractPressed { get; private set; }
+    public bool  FlashlightTogglePressed { get; private set; }
+    public bool  SwitchCharacterPressed  { get; private set; }
+    public bool  MergeTogglePressed      { get; private set; }
 
     void OnEnable()
     {
         move?.action?.Enable();
         jump?.action?.Enable();
         interact?.action?.Enable();
+        flashlightToggle?.action?.Enable();
+        switchCharacter?.action?.Enable();
+        mergeToggle?.action?.Enable();
     }
     void OnDisable()
     {
         move?.action?.Disable();
         jump?.action?.Disable();
         interact?.action?.Disable();
+        flashlightToggle?.action?.Disable();
+        switchCharacter?.action?.Disable();
+        mergeToggle?.action?.Disable();
+    }
+
+    void Update()
+    {
+        Collect();
+    }
+
+    void LateUpdate()
+    {
+        ClearFrameEdges();
     }
 
     public void Collect()
@@ -36,11 +59,17 @@ public class InputAdapter : MonoBehaviour
         JumpHeld = jump && jump.action.IsPressed();
         JumpPressed = jump && jump.action.WasPressedThisFrame();
         InteractPressed = interact && interact.action.WasPressedThisFrame();
+        FlashlightTogglePressed = flashlightToggle && flashlightToggle.action.WasPressedThisFrame();
+        SwitchCharacterPressed  = switchCharacter && switchCharacter.action.WasPressedThisFrame();
+        MergeTogglePressed      = mergeToggle && mergeToggle.action.WasPressedThisFrame();
     }
 
     public void ClearFrameEdges()
     {
         JumpPressed = false;
         InteractPressed = false;
+        FlashlightTogglePressed = false;
+        SwitchCharacterPressed  = false;
+        MergeTogglePressed      = false;
     }
 }

--- a/Assets/scripts/InteractionController.cs
+++ b/Assets/scripts/InteractionController.cs
@@ -5,15 +5,20 @@ public class InteractionController : MonoBehaviour
 {
     InputAdapter input;
     Sensors2D sensors;
+    AbilityRuntime abilities;
 
     void Awake()
     {
         input = GetComponent<InputAdapter>();
         sensors = GetComponent<Sensors2D>();
+        abilities = GetComponent<AbilityRuntime>();
     }
 
     public void Tick(float dt)
     {
+        if (abilities && !abilities.CanInteract)
+            return;
+
         if (input.InteractPressed && sensors.nearestInteractable)
             sensors.nearestInteractable.Activate();
     }

--- a/Assets/scripts/JumpController.cs
+++ b/Assets/scripts/JumpController.cs
@@ -10,6 +10,7 @@ public class JumpController : MonoBehaviour
     Sensors2D sensors;
     LocomotionMotor2D motor;
     PlayerStateMachine fsm;
+    AbilityRuntime abilities;
 
     float coyoteMsLeft;
     float bufferMsLeft;
@@ -20,10 +21,18 @@ public class JumpController : MonoBehaviour
         sensors = GetComponent<Sensors2D>();
         motor = GetComponent<LocomotionMotor2D>();
         fsm = GetComponent<PlayerStateMachine>();
+        abilities = GetComponent<AbilityRuntime>();
     }
 
     public void Tick(float dt)
     {
+        if (abilities && !abilities.CanJump)
+        {
+            coyoteMsLeft = 0f;
+            bufferMsLeft = 0f;
+            return;
+        }
+
         // coyote
         if (sensors.isGrounded) coyoteMsLeft = jumpCfg ? jumpCfg.coyoteMs : 150f;
         else coyoteMsLeft = Mathf.Max(0f, coyoteMsLeft - dt * 1000f);

--- a/Assets/scripts/MergeController.cs
+++ b/Assets/scripts/MergeController.cs
@@ -1,0 +1,298 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class MergeController : MonoBehaviour
+{
+    public enum TransitionKind
+    {
+        Merge,
+        Split
+    }
+
+    [Header("Referanslar")]
+    [Tooltip("Aktif ajan durumunu yöneten CharacterSwitcher.")]
+    [SerializeField] CharacterSwitcher switcher;
+
+    [Tooltip("Elior kök GameObject (boşsa bu nesne kullanılır).")]
+    [SerializeField] GameObject eliorRoot;
+
+    [Tooltip("Sim kök GameObject")]
+    [SerializeField] GameObject simRoot;
+
+    [Tooltip("Merge/Split tetiklerini taşıyan Animator.")]
+    [SerializeField] Animator animator;
+
+    [Header("Animasyon Ayarları")]
+    [Tooltip("Merge akışını tetikleyen trigger adı.")]
+    [SerializeField] string mergeTriggerName = "MergeTrigger";
+
+    [Tooltip("Split akışını tetikleyen trigger adı.")]
+    [SerializeField] string splitTriggerName = "SplitTrigger";
+
+    [Tooltip("Yeni bir trigger ateşlenirken diğer trigger temizlensin mi?")]
+    [SerializeField] bool resetOppositeTrigger = true;
+
+    [Header("Split Çıkışı")]
+    [Tooltip("Sim spawn edilirken Elior'a uygulanacak birincil ofset.")]
+    [SerializeField] Vector2 primarySplitOffset = new(1.25f, 0f);
+
+    [Tooltip("Birincil nokta doluysa denenecek alternatif ofset.")]
+    [SerializeField] Vector2 secondarySplitOffset = new(-1.25f, 0f);
+
+    [Tooltip("Spawn pozisyonu kontrolünde kullanılacak yarıçap.")]
+    [SerializeField] float spawnCheckRadius = 0.45f;
+
+    [Tooltip("Split spawn alanı için çakışma maskesi.")]
+    [SerializeField] LayerMask spawnCollisionMask = ~0;
+
+    [Header("Davranış")]
+    [Tooltip("Merge sırasında Sim otomatik olarak devre dışı bırakılsın mı?")]
+    [SerializeField] bool disableSimWhenMerged = true;
+
+    [Tooltip("TransitionLock aktifken hareketli bileşenlerin hızı sıfırlansın mı?")]
+    [SerializeField] bool zeroVelocityOnTransition = true;
+
+    [Tooltip("Time.timeScale <= 0 olduğunda akış başlatma.")]
+    [SerializeField] bool respectPauseState = true;
+
+    [Tooltip("Akış başlangıç/bitişleri loglansın mı?")]
+    [SerializeField] bool logTransitions = true;
+
+    TransitionKind? currentTransition;
+    bool warnedMissingAnimator;
+    bool warnedMissingSim;
+
+    void Awake()
+    {
+        switcher ??= GetComponent<CharacterSwitcher>();
+        eliorRoot ??= gameObject;
+        animator ??= GetComponentInChildren<Animator>();
+    }
+
+    public void RegisterSwitcher(CharacterSwitcher newSwitcher)
+    {
+        switcher = newSwitcher;
+    }
+
+    public bool BeginMerge()
+    {
+        if (respectPauseState && Time.timeScale <= 0f)
+            return false;
+
+        if (currentTransition.HasValue)
+            return false;
+
+        if (!simRoot)
+        {
+            if (!warnedMissingSim)
+            {
+                Debug.LogWarning("[MergeController] Sim referansı atanmamış.", this);
+                warnedMissingSim = true;
+            }
+            return false;
+        }
+
+        if (disableSimWhenMerged)
+        {
+            SetActive(simRoot, false);
+        }
+
+        TriggerAnimator(mergeTriggerName, splitTriggerName);
+        currentTransition = TransitionKind.Merge;
+
+        if (zeroVelocityOnTransition)
+        {
+            FreezeMotion();
+        }
+
+        return true;
+    }
+
+    public bool BeginSplit()
+    {
+        if (respectPauseState && Time.timeScale <= 0f)
+            return false;
+
+        if (currentTransition.HasValue)
+            return false;
+
+        if (!simRoot)
+        {
+            if (!warnedMissingSim)
+            {
+                Debug.LogWarning("[MergeController] Sim referansı atanmamış.", this);
+                warnedMissingSim = true;
+            }
+            return false;
+        }
+
+        Vector3 spawnPosition;
+        if (!TryResolveSpawnPosition(out spawnPosition))
+        {
+            if (logTransitions)
+                Debug.LogWarning("[MergeController] Split için güvenli spawn bulunamadı.", this);
+            return false;
+        }
+
+        simRoot.transform.position = spawnPosition;
+        SetActive(simRoot, true);
+        ZeroVelocity(simRoot);
+
+        TriggerAnimator(splitTriggerName, mergeTriggerName);
+        currentTransition = TransitionKind.Split;
+
+        if (zeroVelocityOnTransition)
+        {
+            FreezeMotion();
+        }
+
+        return true;
+    }
+
+    public void OnMergeAnimFinished()
+    {
+        if (currentTransition != TransitionKind.Merge)
+            return;
+
+        if (disableSimWhenMerged)
+        {
+            SetActive(simRoot, false);
+        }
+
+        currentTransition = null;
+        switcher?.NotifyTransitionCompleted(TransitionKind.Merge);
+
+        if (logTransitions)
+            Debug.Log("[MergeController] Merge animasyonu tamamlandı.", this);
+    }
+
+    public void OnSplitAnimFinished()
+    {
+        if (currentTransition != TransitionKind.Split)
+            return;
+
+        currentTransition = null;
+        switcher?.NotifyTransitionCompleted(TransitionKind.Split);
+
+        if (logTransitions)
+            Debug.Log("[MergeController] Split animasyonu tamamlandı.", this);
+    }
+
+    public void CancelActiveTransition()
+    {
+        if (!currentTransition.HasValue)
+            return;
+
+        currentTransition = null;
+        switcher?.NotifyTransitionCancelled();
+    }
+
+    void TriggerAnimator(string triggerToFire, string triggerToReset)
+    {
+        if (!animator)
+        {
+            if (!warnedMissingAnimator)
+            {
+                Debug.LogWarning("[MergeController] Animator referansı bulunamadı.", this);
+                warnedMissingAnimator = true;
+            }
+            return;
+        }
+
+        if (resetOppositeTrigger && !string.IsNullOrEmpty(triggerToReset))
+        {
+            animator.ResetTrigger(triggerToReset);
+        }
+
+        if (!string.IsNullOrEmpty(triggerToFire))
+        {
+            animator.SetTrigger(triggerToFire);
+        }
+    }
+
+    bool TryResolveSpawnPosition(out Vector3 position)
+    {
+        Vector3 basePos = eliorRoot ? eliorRoot.transform.position : transform.position;
+        Vector3 first = basePos + (Vector3)primarySplitOffset;
+        Vector3 second = basePos + (Vector3)secondarySplitOffset;
+
+        if (IsPositionClear(first))
+        {
+            position = first;
+            return true;
+        }
+
+        if (IsPositionClear(second))
+        {
+            position = second;
+            return true;
+        }
+
+        position = basePos;
+        return false;
+    }
+
+    bool IsPositionClear(Vector2 world)
+    {
+        var hits = Physics2D.OverlapCircleAll(world, spawnCheckRadius, spawnCollisionMask);
+        foreach (var hit in hits)
+        {
+            if (!hit)
+                continue;
+
+            if (IsPartOf(hit.transform.gameObject, eliorRoot))
+                continue;
+
+            if (IsPartOf(hit.transform.gameObject, simRoot))
+                continue;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    void FreezeMotion()
+    {
+        ZeroVelocity(eliorRoot);
+        ZeroVelocity(simRoot);
+    }
+
+    void ZeroVelocity(GameObject target)
+    {
+        if (!target)
+            return;
+
+        var rb = target.GetComponent<Rigidbody2D>();
+        if (rb)
+        {
+            rb.linearVelocity = Vector2.zero;
+        }
+
+        var motor = target.GetComponent<LocomotionMotor2D>();
+        if (motor)
+        {
+            motor.RequestHorizontalIntent(0f);
+        }
+    }
+
+    void SetActive(GameObject target, bool value)
+    {
+        if (!target)
+            return;
+
+        if (target.activeSelf != value)
+            target.SetActive(value);
+    }
+
+    bool IsPartOf(GameObject candidate, GameObject root)
+    {
+        if (!candidate || !root)
+            return false;
+
+        if (candidate == root)
+            return true;
+
+        return candidate.transform.IsChildOf(root.transform);
+    }
+}

--- a/Assets/scripts/PlayerOrchestrator.cs
+++ b/Assets/scripts/PlayerOrchestrator.cs
@@ -20,10 +20,8 @@ public class PlayerOrchestrator : MonoBehaviour
 
     void Update()
     {
-        input?.Collect();
         sensors?.Sample();
         abilities?.Tick(Time.deltaTime);
-        input?.ClearFrameEdges();
     }
 
     void FixedUpdate() => motor?.PhysicsStep(Time.fixedDeltaTime);

--- a/Assets/scripts/WallClimbController.cs
+++ b/Assets/scripts/WallClimbController.cs
@@ -10,6 +10,7 @@ public class WallClimbController : MonoBehaviour
     Sensors2D s;
     LocomotionMotor2D motor;
     PlayerStateMachine fsm;
+    AbilityRuntime abilities;
     
     // Wall climb state tracking
     int currentWallDir = 0; // -1 sol, +1 sağ, 0 yok
@@ -20,10 +21,14 @@ public class WallClimbController : MonoBehaviour
         s     = GetComponent<Sensors2D>();
         motor = GetComponent<LocomotionMotor2D>();
         fsm   = GetComponent<PlayerStateMachine>();
+        abilities = GetComponent<AbilityRuntime>();
     }
 
     public void Tick(float dt)
     {
+        if (abilities && !abilities.CanClimb)
+            return;
+
         // WallClimb aktifken kontroller
         if (fsm.Current == PlayerStateMachine.LocoState.WallClimb)
         {

--- a/Assets/scripts/WallJumpController.cs
+++ b/Assets/scripts/WallJumpController.cs
@@ -9,6 +9,7 @@ public class WallJumpController : MonoBehaviour
     Sensors2D sensors;
     LocomotionMotor2D motor;
     PlayerStateMachine fsm;
+    AbilityRuntime abilities;
 
     void Awake()
     {
@@ -16,10 +17,14 @@ public class WallJumpController : MonoBehaviour
         sensors = GetComponent<Sensors2D>();
         motor = GetComponent<LocomotionMotor2D>();
         fsm = GetComponent<PlayerStateMachine>();
+        abilities = GetComponent<AbilityRuntime>();
     }
 
     public void Tick(float dt)
     {
+        if (abilities && !abilities.CanWallJump)
+            return;
+
         // Sadece wall slide sırasında wall jump yapılabilir
         if (fsm.Current != PlayerStateMachine.LocoState.WallSlide) return;
         


### PR DESCRIPTION
## Summary
- add ability set assets and runtime component to gate player modules by configurable booleans
- extend the input adapter and player controllers to respect merge/switch actions and ability gating
- implement character switcher and merge controller components that drive split/merge animations, cooldowns, and transition logging

## Testing
- not run (Unity editor feature)


------
https://chatgpt.com/codex/tasks/task_e_68d5894b135083229e9513cf192c0ad4