### PR TITLE
Add PlayerStateHooks to handle animation hooks

### DIFF
--- a/Assets/Prefabs/char/Elior.prefab
+++ b/Assets/Prefabs/char/Elior.prefab
@@ -111,6 +111,7 @@ GameObject:
   - component: {fileID: 7266910066312278373}
   - component: {fileID: 2756311409834166893}
   - component: {fileID: 572985784947357131}
+  - component: {fileID: 7267477753585598389}
   - component: {fileID: 4094748883903601663}
   - component: {fileID: 2870336855995386357}
   - component: {fileID: 892315661026642317}
@@ -381,13 +382,28 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 92ad357ba5a16cc4eb1018a5678c183a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   anim: {fileID: 2756311409834166893}
   spriteRenderer: {fileID: 2839424260411777706}
   invertX: 0
   flipByScale: 0
   flipRoot: {fileID: 0}
+--- !u!114 &7267477753585598389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4078480644037838795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c19cb5d850fb49f79b4c3d09d2e55b41, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  animationFacade: {fileID: 0}
+  sensors: {fileID: 0}
+  locomotionMotor: {fileID: 0}
 --- !u!114 &4094748883903601663
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2503,13 +2503,28 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 92ad357ba5a16cc4eb1018a5678c183a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   anim: {fileID: 2756311410664245654}
   spriteRenderer: {fileID: 2839424261259682129}
   invertX: 0
   flipByScale: 0
   flipRoot: {fileID: 0}
+--- !u!114 &5948360013630333915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4078480642110948400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c19cb5d850fb49f79b4c3d09d2e55b41, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  animationFacade: {fileID: 2756311410664245654}
+  sensors: {fileID: 4368741750299186679}
+  locomotionMotor: {fileID: 423031407205352638}
 --- !u!114 &695269032839276140
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2820,13 +2835,28 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 92ad357ba5a16cc4eb1018a5678c183a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   anim: {fileID: 4263689126297884480}
   spriteRenderer: {fileID: 4182825245110157191}
   invertX: 0
   flipByScale: 0
   flipRoot: {fileID: 0}
+--- !u!114 &8894465914235312443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2734358688004659942}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c19cb5d850fb49f79b4c3d09d2e55b41, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  animationFacade: {fileID: 4263689126297884480}
+  sensors: {fileID: 2435087637150796577}
+  locomotionMotor: {fileID: 1780365402394516072}
 --- !u!70 &2002600848390550982
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -3028,6 +3058,7 @@ GameObject:
   - component: {fileID: 8769220958720044104}
   - component: {fileID: 4263689126297884480}
   - component: {fileID: 1916404499674130662}
+  - component: {fileID: 8894465914235312443}
   - component: {fileID: 2718116293053744850}
   - component: {fileID: 4233018739030414552}
   - component: {fileID: 1227772311418508448}
@@ -3381,6 +3412,7 @@ GameObject:
   - component: {fileID: 7266910067670839966}
   - component: {fileID: 2756311410664245654}
   - component: {fileID: 572985786309850672}
+  - component: {fileID: 5948360013630333915}
   - component: {fileID: 4094748884196808708}
   - component: {fileID: 2870336856747870734}
   - component: {fileID: 892315661252479606}

--- a/Assets/scripts/characterScripts/AnimationStateSync.cs
+++ b/Assets/scripts/characterScripts/AnimationStateSync.cs
@@ -27,34 +27,15 @@ public class AnimationStateSync : MonoBehaviour
         fsm = GetComponent<PlayerStateMachine>();
         sensors = GetComponent<Sensors2D>();
         motor = GetComponent<LocomotionMotor2D>();
-        if (!anim) anim = GetComponent<AnimationFacade>();
         if (!spriteRenderer) spriteRenderer = GetComponentInChildren<SpriteRenderer>();
         if (!flipRoot) flipRoot = transform;
         baseScale = flipRoot.localScale;
-
-        if (fsm != null)
-        {
-            fsm.OnLocoChanged += (oldS, newS) =>
-            {
-                if (anim && anim.animator)
-                {
-                    if (newS == PlayerStateMachine.LocoState.JumpRise) anim.Trigger("Jump");
-                    if ((newS == PlayerStateMachine.LocoState.Idle || newS == PlayerStateMachine.LocoState.Run) && sensors.justLanded)
-                        anim.Trigger("Land");
-                }
-            };
-            fsm.OnPhaseTriggered += (p) =>
-            {
-                if (anim && anim.animator)
-                {
-                    if (p == PlayerStateMachine.PhaseState.WallJump)  anim.Trigger("WallJump");
-                }
-            };
-        }
     }
 
     public void LateSync()
     {
+        if (!anim) anim = GetComponent<AnimationFacade>();
+
         // Animator paramları (sadece animator varsa)
         if (anim && anim.animator)
         {

--- a/Assets/scripts/characterScripts/PlayerStateHooks.cs
+++ b/Assets/scripts/characterScripts/PlayerStateHooks.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(PlayerStateMachine))]
+public class PlayerStateHooks : MonoBehaviour
+{
+    [Header("Optional References")]
+    public AnimationFacade animationFacade;
+    public Sensors2D sensors;
+    public LocomotionMotor2D locomotionMotor;
+
+    PlayerStateMachine stateMachine;
+
+    void Awake()
+    {
+        stateMachine = GetComponent<PlayerStateMachine>();
+        if (!animationFacade) animationFacade = GetComponent<AnimationFacade>();
+        if (!sensors) sensors = GetComponent<Sensors2D>();
+        if (!locomotionMotor) locomotionMotor = GetComponent<LocomotionMotor2D>();
+    }
+
+    void OnEnable()
+    {
+        if (stateMachine == null) return;
+        stateMachine.OnLocoChanged += HandleLocoChanged;
+        stateMachine.OnPhaseTriggered += HandlePhaseTriggered;
+    }
+
+    void OnDisable()
+    {
+        if (stateMachine == null) return;
+        stateMachine.OnLocoChanged -= HandleLocoChanged;
+        stateMachine.OnPhaseTriggered -= HandlePhaseTriggered;
+    }
+
+    void HandleLocoChanged(PlayerStateMachine.LocoState previous, PlayerStateMachine.LocoState next)
+    {
+        if (animationFacade == null || animationFacade.animator == null) return;
+
+        if (next == PlayerStateMachine.LocoState.JumpRise)
+        {
+            animationFacade.Trigger("Jump");
+        }
+        else if ((next == PlayerStateMachine.LocoState.Idle || next == PlayerStateMachine.LocoState.Run) && sensors != null && sensors.justLanded)
+        {
+            animationFacade.Trigger("Land");
+        }
+    }
+
+    void HandlePhaseTriggered(PlayerStateMachine.PhaseState phase)
+    {
+        if (animationFacade == null || animationFacade.animator == null) return;
+
+        if (phase == PlayerStateMachine.PhaseState.WallJump)
+        {
+            animationFacade.Trigger("WallJump");
+        }
+    }
+}

--- a/Assets/scripts/characterScripts/PlayerStateHooks.cs.meta
+++ b/Assets/scripts/characterScripts/PlayerStateHooks.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c19cb5d850fb49f79b4c3d09d2e55b41


### PR DESCRIPTION
## Summary
- add a PlayerStateHooks component that subscribes to PlayerStateMachine events and fires animation triggers
- simplify AnimationStateSync to focus on parameter syncing while fetching AnimationFacade lazily
- update the player prefab and SampleScene to include the new component references

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d6ced37e288322ac048f85704ff686