### PR TITLE
Add Cinemachine party camera switching rig

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -348,6 +348,38 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!114 &4278629816050551856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919606455102306768}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ShowDebugText: 0
+  ShowCameraFrustum: 0
+  IgnoreTimeScale: 0
+  WorldUpOverride: {fileID: 0}
+  ChannelMask: 1
+  UpdateMethod: 2
+  BlendUpdateMethod: 1
+  LensModeOverride:
+    Enabled: 0
+    DefaultMode: 2
+  DefaultBlend:
+    Style: 0
+    Time: 2
+    CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  CustomBlends: {fileID: 0}
 --- !u!81 &597558347
 AudioListener:
   m_ObjectHideFlags: 0
@@ -2769,6 +2801,7 @@ GameObject:
   - component: {fileID: 4133720098407980929}
   - component: {fileID: 8107148393402467773}
   - component: {fileID: 2190065993609557020}
+  - component: {fileID: 4278629816050551856}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -4153,8 +4186,56 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 70eb69b8e677ae042af75af39770ff4e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1 &8802307930059469650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1372722340457222903}
+  - component: {fileID: 3904181905505868244}
+  m_Layer: 0
+  m_Name: CinemachinePartySwitcher
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1372722340457222903
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8802307930059469650}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3904181905505868244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8802307930059469650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 929fc59b35b94806bb47400b758b8dd4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  party: {fileID: 0}
+  vcamMerged: {fileID: 0}
+  vcamElior: {fileID: 0}
+  vcamSim: {fileID: 0}
 --- !u!1 &8945255109295074980
 GameObject:
   m_ObjectHideFlags: 0
@@ -4209,3 +4290,4 @@ SceneRoots:
   - {fileID: 2052933735}
   - {fileID: 4091461929922832777}
   - {fileID: 6941720982547793704}
+  - {fileID: 1372722340457222903}

--- a/Assets/Scripts/camera.meta
+++ b/Assets/Scripts/camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: adef869a2b26471cbd7e0ff697f2cdb5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/camera/CinemachinePartySwitcher.cs
+++ b/Assets/Scripts/camera/CinemachinePartySwitcher.cs
@@ -1,0 +1,124 @@
+using Unity.Cinemachine;
+using UnityEngine;
+
+public class CinemachinePartySwitcher : MonoBehaviour
+{
+    public DualCharacterController party;
+    public CinemachineVirtualCamera vcamMerged;
+    public CinemachineVirtualCamera vcamElior;
+    public CinemachineVirtualCamera vcamSim;
+
+    void Start()
+    {
+        if (!party)
+            party = FindObjectOfType<DualCharacterController>();
+
+        vcamMerged = EnsureCamera(vcamMerged, "vcam_Merged");
+        vcamElior = EnsureCamera(vcamElior, "vcam_Elior");
+        vcamSim = EnsureCamera(vcamSim, "vcam_Sim");
+
+        ConfigureCameras();
+
+        if (party)
+        {
+            party.OnActiveCharacterChanged.AddListener(OnActiveChanged);
+            party.OnMergedStateChanged.AddListener(OnMergedChanged);
+        }
+
+        ApplyState();
+    }
+
+    CinemachineVirtualCamera EnsureCamera(CinemachineVirtualCamera cam, string name)
+    {
+        if (cam)
+            return cam;
+
+        var go = new GameObject(name);
+        go.transform.SetParent(transform, false);
+        cam = go.AddComponent<CinemachineVirtualCamera>();
+        return cam;
+    }
+
+    void ConfigureCameras()
+    {
+        Transform eliorTarget = party && party.elior ? party.elior.transform : null;
+        Transform simTarget = party && party.sim ? party.sim.transform : null;
+
+        SetupCamera(vcamMerged, eliorTarget, 55f, 30, true);
+        SetupCamera(vcamElior, eliorTarget, 50f, 10, false);
+        SetupCamera(vcamSim, simTarget, 48f, 10, false);
+    }
+
+    void SetupCamera(CinemachineVirtualCamera cam, Transform follow, float fieldOfView, int defaultPriority, bool ensureFraming)
+    {
+        if (!cam)
+            return;
+
+        cam.m_Lens.FieldOfView = fieldOfView;
+        cam.m_Lens.ModeOverride = LensSettings.OverrideModes.None;
+
+        if (follow)
+        {
+            cam.Follow = follow;
+            cam.LookAt = follow;
+        }
+
+        cam.Priority = defaultPriority;
+
+        if (!ensureFraming)
+            return;
+
+        var body = cam.GetCinemachineComponent<CinemachineFramingTransposer>()
+            ?? cam.AddCinemachineComponent<CinemachineFramingTransposer>();
+        if (body != null)
+        {
+            body.m_CameraDistance = 8f;
+            var offset = body.m_TrackedObjectOffset;
+            offset.z = -8f;
+            body.m_TrackedObjectOffset = offset;
+        }
+    }
+
+    public void OnActiveChanged(string who)
+    {
+        ApplyState();
+    }
+
+    public void OnMergedChanged(bool merged)
+    {
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        if (vcamMerged == null && vcamElior == null && vcamSim == null)
+            return;
+
+        ConfigureCameras();
+
+        if (party == null)
+        {
+            SetPri(30, 10, 10);
+            return;
+        }
+
+        if (party.IsMerged)
+        {
+            SetPri(30, 5, 5);
+            return;
+        }
+
+        bool eliorActive = party.Active == party.elior;
+        SetPri(5, eliorActive ? 30 : 10, eliorActive ? 10 : 30);
+    }
+
+    void SetPri(int merged, int elior, int sim)
+    {
+        if (vcamMerged)
+            vcamMerged.Priority = merged;
+        if (vcamElior)
+            vcamElior.Priority = elior;
+        if (vcamSim)
+            vcamSim.Priority = sim;
+    }
+}

--- a/Assets/Scripts/camera/CinemachinePartySwitcher.cs.meta
+++ b/Assets/Scripts/camera/CinemachinePartySwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 929fc59b35b94806bb47400b758b8dd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": "2.9.3",
+    "com.unity.cinemachine": "3.1.5",
     "com.unity.feature.2d": "2.0.1",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.23",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -556,6 +556,23 @@
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.unity.modules.subsystems": "1.0.0"
       }
+    },
+    "com.unity.splines": {
+      "version": "2.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.cinemachine": {
+      "version": "3.1.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.splines": "2.0.0",
+        "com.unity.modules.imgui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the Cinemachine package so the project can use virtual cameras and blending
- wire a Cinemachine brain and party switcher that spawns/maintains the active virtual cameras for merged, Elior, and Sim states

## Testing
- not run (Unity editor not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7554568c88322bb61b8c2cc08eef5