### PR TITLE
Add Cinemachine party camera switching system

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e0805bda5fdafb4aaed47dc6e5bce9c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/CameraAutoSetup.cs
+++ b/Assets/Editor/CameraAutoSetup.cs
@@ -1,0 +1,152 @@
+using UnityEditor;
+using UnityEngine;
+using Unity.Cinemachine;
+
+public static class CameraAutoSetup
+{
+    private const string MenuPath = "Tools/Camera/Auto-Create Party VCams";
+
+    [MenuItem(MenuPath)]
+    public static void AutoCreatePartyVCams()
+    {
+        var party = Object.FindObjectOfType<DualCharacterController>();
+        if (!party)
+        {
+            Debug.LogWarning("No DualCharacterController found in the scene.");
+            return;
+        }
+
+        var mainCamera = Camera.main;
+        if (!mainCamera)
+        {
+            Debug.LogWarning("Main Camera not found in the scene.");
+            return;
+        }
+
+        EnsureBrain(mainCamera);
+
+        var elior = party.elior ? party.elior.transform : null;
+        var sim = party.sim ? party.sim.transform : null;
+        if (!elior || !sim)
+        {
+            Debug.LogWarning("Elior or Sim transforms not found on DualCharacterController.");
+            return;
+        }
+
+        var mergedCam = FindOrCreateCamera("vcam_Merged", elior);
+        var eliorCam = FindOrCreateCamera("vcam_Elior", elior);
+        var simCam = FindOrCreateCamera("vcam_Sim", sim);
+
+        mergedCam.Priority = 30;
+        eliorCam.Priority = 10;
+        simCam.Priority = 10;
+
+        var switcher = EnsureSwitcher(party, mergedCam, eliorCam, simCam);
+        AssignProfiles(switcher);
+
+        EditorUtility.SetDirty(switcher);
+        Debug.Log("Camera setup completed.");
+    }
+
+    private static CinemachineCamera FindOrCreateCamera(string name, Transform follow)
+    {
+        var existing = GameObject.Find(name);
+        CinemachineCamera camera;
+        if (existing)
+        {
+            camera = existing.GetComponent<CinemachineCamera>();
+            if (!camera)
+            {
+                camera = existing.AddComponent<CinemachineCamera>();
+            }
+        }
+        else
+        {
+            existing = new GameObject(name);
+            camera = existing.AddComponent<CinemachineCamera>();
+        }
+
+        camera.Follow = follow;
+        return camera;
+    }
+
+    private static void EnsureBrain(Camera camera)
+    {
+        if (!camera.TryGetComponent(out Unity.Cinemachine.CinemachineBrain brain))
+        {
+            brain = camera.gameObject.AddComponent<Unity.Cinemachine.CinemachineBrain>();
+        }
+
+        brain.DefaultBlend.BlendCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        brain.DefaultBlend.Duration = 0.5f;
+    }
+
+    private static CinemachinePartySwitcher EnsureSwitcher(DualCharacterController party, CinemachineCamera merged, CinemachineCamera elior, CinemachineCamera sim)
+    {
+        const string switcherName = "CinemachinePartySwitcher";
+        var switcherObj = GameObject.Find(switcherName);
+        if (!switcherObj)
+        {
+            switcherObj = new GameObject(switcherName);
+        }
+
+        if (!switcherObj.TryGetComponent(out CinemachinePartySwitcher switcher))
+        {
+            switcher = switcherObj.AddComponent<CinemachinePartySwitcher>();
+        }
+
+        switcher.party = party;
+        switcher.vcamMerged = merged;
+        switcher.vcamElior = elior;
+        switcher.vcamSim = sim;
+
+        return switcher;
+    }
+
+    private static void AssignProfiles(CinemachinePartySwitcher switcher)
+    {
+        if (!switcher)
+        {
+            return;
+        }
+
+        var directory = "Assets/Configs/Camera";
+        if (!AssetDatabase.IsValidFolder(directory))
+        {
+            CreateFolders("Assets/Configs", "Camera");
+        }
+
+        switcher.mergedProfile = FindOrCreateProfile(directory + "/CameraProfile_Merged.asset");
+        switcher.eliorProfile = FindOrCreateProfile(directory + "/CameraProfile_Elior.asset");
+        switcher.simProfile = FindOrCreateProfile(directory + "/CameraProfile_Sim.asset");
+    }
+
+    private static CameraProfile FindOrCreateProfile(string path)
+    {
+        var profile = AssetDatabase.LoadAssetAtPath<CameraProfile>(path);
+        if (!profile)
+        {
+            profile = ScriptableObject.CreateInstance<CameraProfile>();
+            AssetDatabase.CreateAsset(profile, path);
+        }
+
+        return profile;
+    }
+
+    private static void CreateFolders(string basePath, string leaf)
+    {
+        if (!AssetDatabase.IsValidFolder(basePath))
+        {
+            var parent = System.IO.Path.GetDirectoryName(basePath);
+            if (!string.IsNullOrEmpty(parent))
+            {
+                CreateFolders(parent.Replace('\\', '/'), System.IO.Path.GetFileName(basePath));
+            }
+        }
+
+        if (!AssetDatabase.IsValidFolder(basePath + "/" + leaf))
+        {
+            AssetDatabase.CreateFolder(basePath, leaf);
+        }
+    }
+}

--- a/Assets/Editor/CameraAutoSetup.cs
+++ b/Assets/Editor/CameraAutoSetup.cs
@@ -67,6 +67,7 @@ public static class CameraAutoSetup
         }
 
         camera.Follow = follow;
+        Debug.Log($"Camera {name} follow target set to: {follow.name} (Position: {follow.position})");
         return camera;
     }
 
@@ -77,8 +78,8 @@ public static class CameraAutoSetup
             brain = camera.gameObject.AddComponent<Unity.Cinemachine.CinemachineBrain>();
         }
 
-        brain.DefaultBlend.BlendCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-        brain.DefaultBlend.Duration = 0.5f;
+        brain.DefaultBlend = new Unity.Cinemachine.CinemachineBlendDefinition(
+            Unity.Cinemachine.CinemachineBlendDefinition.Styles.EaseInOut, 0.5f);
     }
 
     private static CinemachinePartySwitcher EnsureSwitcher(DualCharacterController party, CinemachineCamera merged, CinemachineCamera elior, CinemachineCamera sim)

--- a/Assets/Editor/CameraAutoSetup.cs.meta
+++ b/Assets/Editor/CameraAutoSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 650904882c316fc4699398c07b604adb

--- a/Assets/Scripts/camera/CameraProfile.cs
+++ b/Assets/Scripts/camera/CameraProfile.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Camera/Party Profile", fileName = "CameraProfile")]
+public class CameraProfile : ScriptableObject
+{
+    public Vector3 followOffset = new Vector3(0.6f, 1.6f, -8f);
+    public float positionDamping = 0.15f;
+    public float fov = 55f;
+}

--- a/Assets/Scripts/camera/CameraProfile.cs.meta
+++ b/Assets/Scripts/camera/CameraProfile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b46f2c0285ba85643aae335083d20096

--- a/Assets/Scripts/camera/CinemachinePartySwitcher.cs
+++ b/Assets/Scripts/camera/CinemachinePartySwitcher.cs
@@ -16,20 +16,27 @@ public class CinemachinePartySwitcher : MonoBehaviour
     public CameraProfile eliorProfile;
     public CameraProfile simProfile;
 
+    [Header("Debug")]
+    public bool enableDebugLogs = true;
+
     private void Awake()
     {
+        DebugLog("CinemachinePartySwitcher başlatılıyor...");
+        
         if (!party)
         {
             party = FindObjectOfType<DualCharacterController>();
+            if (party)
+                DebugLog("DualCharacterController bulundu: " + party.name);
+            else
+                DebugLogError("DualCharacterController bulunamadı!");
         }
-
-        var brain = Camera.main ? Camera.main.GetComponent<Unity.Cinemachine.CinemachineBrain>() : null;
-        if (brain)
+        else
         {
-            brain.DefaultBlend.BlendCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-            brain.DefaultBlend.Duration = 0.5f;
+            DebugLog("DualCharacterController referansı mevcut: " + party.name);
         }
 
+        SetupCinemachineBrain();
         ApplyProfiles();
     }
 
@@ -39,6 +46,7 @@ public class CinemachinePartySwitcher : MonoBehaviour
         {
             party.OnActiveCharacterChanged.AddListener(OnActiveChanged);
             party.OnMergedStateChanged.AddListener(OnMergedChanged);
+            DebugLog("Event listener'lar bağlandı");
         }
 
         ApplyState();
@@ -50,81 +58,276 @@ public class CinemachinePartySwitcher : MonoBehaviour
         {
             party.OnActiveCharacterChanged.RemoveListener(OnActiveChanged);
             party.OnMergedStateChanged.RemoveListener(OnMergedChanged);
+            DebugLog("Event listener'lar kaldırıldı");
         }
     }
 
-    public void OnActiveChanged(string _)
+    public void OnActiveChanged(string characterName)
     {
+        DebugLog($"Aktif karakter değişti: {characterName}");
         ApplyState();
     }
 
-    public void OnMergedChanged(bool _)
+    public void OnMergedChanged(bool isMerged)
     {
+        DebugLog($"Merge durumu değişti: {(isMerged ? "Merged" : "Split")}");
         ApplyState();
+    }
+
+    private void SetupCinemachineBrain()
+    {
+        DebugLog("CinemachineBrain kurulumu kontrol ediliyor...");
+        
+        var mainCamera = Camera.main;
+        if (!mainCamera)
+        {
+            DebugLogError("Main Camera bulunamadı!");
+            return;
+        }
+
+        var brain = mainCamera.GetComponent<Unity.Cinemachine.CinemachineBrain>();
+        if (!brain)
+        {
+            DebugLog("CinemachineBrain Main Camera'ya ekleniyor...");
+            brain = mainCamera.gameObject.AddComponent<Unity.Cinemachine.CinemachineBrain>();
+            DebugLog("CinemachineBrain başarıyla eklendi");
+        }
+        else
+        {
+            DebugLog("CinemachineBrain zaten mevcut");
+        }
+
+        // Main Camera depth'ini düşür
+        if (mainCamera.depth >= 0)
+        {
+            mainCamera.depth = -1;
+            DebugLog("Main Camera depth -1 olarak ayarlandı");
+        }
+
+        // Cinemachine kameraları otomatik bul
+        if (!vcamMerged || !vcamElior || !vcamSim)
+        {
+            DebugLog("Cinemachine kameraları otomatik bulunuyor...");
+            
+            var allCinemachineCameras = FindObjectsOfType<Unity.Cinemachine.CinemachineCamera>();
+            DebugLog($"Sahnede {allCinemachineCameras.Length} Cinemachine kamerası bulundu");
+            
+            foreach (var cam in allCinemachineCameras)
+            {
+                string camName = cam.name.ToLower();
+                DebugLog($"Kamera bulundu: {cam.name}");
+                
+                if (camName.Contains("merge") || camName.Contains("merged"))
+                {
+                    vcamMerged = cam;
+                    DebugLog($"vcamMerged atandı: {cam.name}");
+                }
+                else if (camName.Contains("elior"))
+                {
+                    vcamElior = cam;
+                    DebugLog($"vcamElior atandı: {cam.name}");
+                }
+                else if (camName.Contains("sim"))
+                {
+                    vcamSim = cam;
+                    DebugLog($"vcamSim atandı: {cam.name}");
+                }
+            }
+        }
+
+        // Follow target'ları ayarla
+        SetupFollowTargets();
+    }
+
+    private void SetupFollowTargets()
+    {
+        DebugLog("Follow target'ları ayarlanıyor...");
+        
+        if (!party)
+        {
+            DebugLogError("Party referansı yok!");
+            return;
+        }
+
+        var elior = party.elior;
+        var sim = party.sim;
+        
+        if (!elior)
+        {
+            DebugLogError("Elior karakteri bulunamadı!");
+            return;
+        }
+        
+        if (!sim)
+        {
+            DebugLogError("Sim karakteri bulunamadı!");
+            return;
+        }
+
+        DebugLog($"Elior transform: {elior.transform.name} - Position: {elior.transform.position}");
+        DebugLog($"Sim transform: {sim.transform.name} - Position: {sim.transform.position}");
+
+        // Follow target'ları ayarla
+        if (vcamMerged)
+        {
+            vcamMerged.Follow = elior.transform;
+            DebugLog($"vcamMerged follow target: {elior.name} (Transform: {elior.transform.name})");
+            
+            // Follow target'ın doğru atandığını kontrol et
+            if (vcamMerged.Follow == elior.transform)
+            {
+                DebugLog("vcamMerged follow target başarıyla atandı!");
+            }
+            else
+            {
+                DebugLogError($"vcamMerged follow target atanamadı! Beklenen: {elior.transform.name}, Atanan: {(vcamMerged.Follow ? vcamMerged.Follow.name : "null")}");
+            }
+        }
+
+        if (vcamElior)
+        {
+            vcamElior.Follow = elior.transform;
+            DebugLog($"vcamElior follow target: {elior.name} (Transform: {elior.transform.name})");
+            
+            if (vcamElior.Follow == elior.transform)
+            {
+                DebugLog("vcamElior follow target başarıyla atandı!");
+            }
+            else
+            {
+                DebugLogError($"vcamElior follow target atanamadı! Beklenen: {elior.transform.name}, Atanan: {(vcamElior.Follow ? vcamElior.Follow.name : "null")}");
+            }
+        }
+
+        if (vcamSim)
+        {
+            vcamSim.Follow = sim.transform;
+            DebugLog($"vcamSim follow target: {sim.name} (Transform: {sim.transform.name})");
+            
+            if (vcamSim.Follow == sim.transform)
+            {
+                DebugLog("vcamSim follow target başarıyla atandı!");
+            }
+            else
+            {
+                DebugLogError($"vcamSim follow target atanamadı! Beklenen: {sim.transform.name}, Atanan: {(vcamSim.Follow ? vcamSim.Follow.name : "null")}");
+            }
+        }
+
+        DebugLog("Follow target'ları ayarlama tamamlandı!");
     }
 
     private void ApplyProfiles()
     {
-        void Setup(CinemachineCamera cam, CameraProfile profile)
+        DebugLog("Camera profile'ları uygulanıyor...");
+        
+        SetupCameraProfile(vcamMerged, mergedProfile, "Merged");
+        SetupCameraProfile(vcamElior, eliorProfile, "Elior");
+        SetupCameraProfile(vcamSim, simProfile, "Sim");
+    }
+
+    private void SetupCameraProfile(Unity.Cinemachine.CinemachineCamera cam, CameraProfile profile, string name)
+    {
+        if (!cam)
         {
-            if (!cam || !profile)
-            {
-                return;
-            }
-
-            var composer = cam.GetComponent<CinemachinePositionComposer>();
-            if (!composer)
-            {
-                composer = cam.gameObject.AddComponent<CinemachinePositionComposer>();
-            }
-
-            composer.TrackedObjectOffset = new Vector3(profile.followOffset.x, profile.followOffset.y, 0f);
-            composer.Damping = new Vector3(profile.positionDamping, profile.positionDamping, profile.positionDamping);
-            cam.Lens.FieldOfView = profile.fov;
-
-            var transform = cam.transform;
-            var position = transform.localPosition;
-            position.z = profile.followOffset.z;
-            transform.localPosition = position;
+            DebugLogWarning($"{name} kamerası bulunamadı!");
+            return;
         }
 
-        Setup(vcamMerged, mergedProfile);
-        Setup(vcamElior, eliorProfile);
-        Setup(vcamSim, simProfile);
+        if (!profile)
+        {
+            DebugLogWarning($"{name} profile'ı bulunamadı!");
+            return;
+        }
+
+        DebugLog($"{name} kamerası için profile uygulanıyor...");
+
+        // Lens ayarları (sadece FOV)
+        cam.Lens.FieldOfView = profile.fov;
+        DebugLog($"{name} FOV: {profile.fov}");
+
+        // Kamera pozisyonunu ayarla (basit çözüm)
+        var camTransform = cam.transform;
+        var newPosition = camTransform.position;
+        newPosition.x = profile.followOffset.x;
+        newPosition.y = profile.followOffset.y;
+        newPosition.z = profile.followOffset.z;
+        camTransform.position = newPosition;
+        
+        DebugLog($"{name} kamera pozisyonu ayarlandı: {newPosition}");
     }
 
     private void ApplyState()
     {
         if (!party)
         {
+            DebugLogError("Party referansı yok, kamera değişimi yapılamıyor!");
             return;
         }
 
         if (party.IsMerged)
         {
+            DebugLog("Merged durumda - Merged kamera aktif ediliyor");
             SetPriority(30, 5, 5);
             return;
         }
 
         bool eliorActive = party.Active == party.elior;
+        string activeChar = eliorActive ? "Elior" : "Sim";
+        DebugLog($"Split durumda - Aktif karakter: {activeChar}");
         SetPriority(5, eliorActive ? 30 : 10, eliorActive ? 10 : 30);
     }
 
     private void SetPriority(int merged, int elior, int sim)
     {
+        DebugLog($"Kamera öncelikleri ayarlanıyor - Merged: {merged}, Elior: {elior}, Sim: {sim}");
+        
         if (vcamMerged)
         {
             vcamMerged.Priority = merged;
+            DebugLog($"vcamMerged önceliği: {merged}");
+        }
+        else
+        {
+            DebugLogWarning("vcamMerged referansı yok!");
         }
 
         if (vcamElior)
         {
             vcamElior.Priority = elior;
+            DebugLog($"vcamElior önceliği: {elior}");
+        }
+        else
+        {
+            DebugLogWarning("vcamElior referansı yok!");
         }
 
         if (vcamSim)
         {
             vcamSim.Priority = sim;
+            DebugLog($"vcamSim önceliği: {sim}");
         }
+        else
+        {
+            DebugLogWarning("vcamSim referansı yok!");
+        }
+    }
+
+    private void DebugLog(string message)
+    {
+        if (enableDebugLogs)
+            Debug.Log($"[CinemachinePartySwitcher] {message}");
+    }
+
+    private void DebugLogWarning(string message)
+    {
+        if (enableDebugLogs)
+            Debug.LogWarning($"[CinemachinePartySwitcher] {message}");
+    }
+
+    private void DebugLogError(string message)
+    {
+        if (enableDebugLogs)
+            Debug.LogError($"[CinemachinePartySwitcher] {message}");
     }
 }

--- a/Assets/Scripts/camera/CinemachinePartySwitcher.cs
+++ b/Assets/Scripts/camera/CinemachinePartySwitcher.cs
@@ -1,0 +1,130 @@
+using UnityEngine;
+using Unity.Cinemachine;
+
+public class CinemachinePartySwitcher : MonoBehaviour
+{
+    [Header("Party")]
+    public DualCharacterController party;
+
+    [Header("Cameras")]
+    public CinemachineCamera vcamMerged;
+    public CinemachineCamera vcamElior;
+    public CinemachineCamera vcamSim;
+
+    [Header("Profiles")]
+    public CameraProfile mergedProfile;
+    public CameraProfile eliorProfile;
+    public CameraProfile simProfile;
+
+    private void Awake()
+    {
+        if (!party)
+        {
+            party = FindObjectOfType<DualCharacterController>();
+        }
+
+        var brain = Camera.main ? Camera.main.GetComponent<Unity.Cinemachine.CinemachineBrain>() : null;
+        if (brain)
+        {
+            brain.DefaultBlend.BlendCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+            brain.DefaultBlend.Duration = 0.5f;
+        }
+
+        ApplyProfiles();
+    }
+
+    private void OnEnable()
+    {
+        if (party)
+        {
+            party.OnActiveCharacterChanged.AddListener(OnActiveChanged);
+            party.OnMergedStateChanged.AddListener(OnMergedChanged);
+        }
+
+        ApplyState();
+    }
+
+    private void OnDisable()
+    {
+        if (party)
+        {
+            party.OnActiveCharacterChanged.RemoveListener(OnActiveChanged);
+            party.OnMergedStateChanged.RemoveListener(OnMergedChanged);
+        }
+    }
+
+    public void OnActiveChanged(string _)
+    {
+        ApplyState();
+    }
+
+    public void OnMergedChanged(bool _)
+    {
+        ApplyState();
+    }
+
+    private void ApplyProfiles()
+    {
+        void Setup(CinemachineCamera cam, CameraProfile profile)
+        {
+            if (!cam || !profile)
+            {
+                return;
+            }
+
+            var composer = cam.GetComponent<CinemachinePositionComposer>();
+            if (!composer)
+            {
+                composer = cam.gameObject.AddComponent<CinemachinePositionComposer>();
+            }
+
+            composer.TrackedObjectOffset = new Vector3(profile.followOffset.x, profile.followOffset.y, 0f);
+            composer.Damping = new Vector3(profile.positionDamping, profile.positionDamping, profile.positionDamping);
+            cam.Lens.FieldOfView = profile.fov;
+
+            var transform = cam.transform;
+            var position = transform.localPosition;
+            position.z = profile.followOffset.z;
+            transform.localPosition = position;
+        }
+
+        Setup(vcamMerged, mergedProfile);
+        Setup(vcamElior, eliorProfile);
+        Setup(vcamSim, simProfile);
+    }
+
+    private void ApplyState()
+    {
+        if (!party)
+        {
+            return;
+        }
+
+        if (party.IsMerged)
+        {
+            SetPriority(30, 5, 5);
+            return;
+        }
+
+        bool eliorActive = party.Active == party.elior;
+        SetPriority(5, eliorActive ? 30 : 10, eliorActive ? 10 : 30);
+    }
+
+    private void SetPriority(int merged, int elior, int sim)
+    {
+        if (vcamMerged)
+        {
+            vcamMerged.Priority = merged;
+        }
+
+        if (vcamElior)
+        {
+            vcamElior.Priority = elior;
+        }
+
+        if (vcamSim)
+        {
+            vcamSim.Priority = sim;
+        }
+    }
+}

--- a/Assets/Scripts/camera/CinemachinePartySwitcher.cs.meta
+++ b/Assets/Scripts/camera/CinemachinePartySwitcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 210eb859ce171b34eb56bd3e21cc54e9

--- a/Assets/configs/Camera/CameraProfile_Elior.asset
+++ b/Assets/configs/Camera/CameraProfile_Elior.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b46f2c0285ba85643aae335083d20096, type: 3}
+  m_Name: CameraProfile_Elior
+  m_EditorClassIdentifier: 
+  followOffset: {x: 0.6, y: 1.6, z: -8}
+  positionDamping: 0.15
+  fov: 55

--- a/Assets/configs/Camera/CameraProfile_Elior.asset.meta
+++ b/Assets/configs/Camera/CameraProfile_Elior.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa30129a2b2eb7f4098143ffd6557890
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/configs/Camera/CameraProfile_Merged.asset
+++ b/Assets/configs/Camera/CameraProfile_Merged.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b46f2c0285ba85643aae335083d20096, type: 3}
+  m_Name: CameraProfile_Merged
+  m_EditorClassIdentifier: 
+  followOffset: {x: 0.6, y: 1.6, z: -8}
+  positionDamping: 0.15
+  fov: 55

--- a/Assets/configs/Camera/CameraProfile_Merged.asset.meta
+++ b/Assets/configs/Camera/CameraProfile_Merged.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a05eb12bbf2da24baa5e93936a88f93
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/configs/Camera/CameraProfile_Sim.asset
+++ b/Assets/configs/Camera/CameraProfile_Sim.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b46f2c0285ba85643aae335083d20096, type: 3}
+  m_Name: CameraProfile_Sim
+  m_EditorClassIdentifier: 
+  followOffset: {x: 0.6, y: 1.6, z: -8}
+  positionDamping: 0.15
+  fov: 55

--- a/Assets/configs/Camera/CameraProfile_Sim.asset.meta
+++ b/Assets/configs/Camera/CameraProfile_Sim.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7cadc5bfb25bf0478943cc10fc583b1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add camera profile ScriptableObject for configurable offsets, damping, and FOV
- implement Cinemachine party switcher to follow merged or active character automatically
- provide editor utility to auto-create virtual cameras, profiles, and switcher wiring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d761e752588322b4331f8f6d830665