### PR TITLE
Add modular interaction node system

### DIFF
--- a/Assets/Prefabs/Interactions.meta
+++ b/Assets/Prefabs/Interactions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cdad902af154886b67eacd2bbb6838f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/InteractionDemo.unity
+++ b/Assets/Scenes/InteractionDemo.unity
@@ -1,0 +1,1323 @@
+
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+
+--- !u!1 &11
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 12}
+  - component: {fileID: 13}
+  - component: {fileID: 14}
+  - component: {fileID: 15}
+  m_Layer: 0
+  m_Name: Door Demo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &12
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &13
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &14
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &15
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7452430735f419d92aff8e87ef1ffac, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &16
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 17}
+  - component: {fileID: 18}
+  - component: {fileID: 19}
+  - component: {fileID: 20}
+  m_Layer: 0
+  m_Name: Timed Switch
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &17
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &18
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &19
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &20
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5e149ddbd7045fcb608afe083627bc0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  durationMs: 2000.0
+
+--- !u!1 &21
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22}
+  - component: {fileID: 23}
+  - component: {fileID: 24}
+  - component: {fileID: 25}
+  m_Layer: 0
+  m_Name: Valve
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &22
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &23
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &24
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &25
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 21}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1c5172804ec49f8bad1d49a35458e0a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &26
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 27}
+  - component: {fileID: 28}
+  - component: {fileID: 29}
+  - component: {fileID: 30}
+  m_Layer: 0
+  m_Name: Dialogue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &27
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &28
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &29
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &30
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e3580595720403f8b69e4764ce6d867, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &31
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 32}
+  - component: {fileID: 33}
+  - component: {fileID: 34}
+  - component: {fileID: 35}
+  m_Layer: 0
+  m_Name: Choice
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &32
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 31}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 8.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &33
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 31}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &34
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 31}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &35
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 31}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b9108024a0634a98937863929b57487f, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &36
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 37}
+  - component: {fileID: 38}
+  - component: {fileID: 39}
+  - component: {fileID: 40}
+  m_Layer: 0
+  m_Name: SFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &37
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &38
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &39
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &40
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4cdbc1d361e4a3e896cb61c13e7388a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &41
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 42}
+  - component: {fileID: 43}
+  - component: {fileID: 44}
+  - component: {fileID: 45}
+  m_Layer: 0
+  m_Name: Light Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &42
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 12.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &43
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &44
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &45
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df7a3da0686440238400658e8a0ecd32, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &46
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 47}
+  - component: {fileID: 48}
+  - component: {fileID: 49}
+  - component: {fileID: 50}
+  m_Layer: 0
+  m_Name: Particle Burst
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &47
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 14.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &48
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &49
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &50
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fe88d8ca0b0481f97723a2ec47096a6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &51
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 52}
+  - component: {fileID: 53}
+  - component: {fileID: 54}
+  - component: {fileID: 55}
+  m_Layer: 0
+  m_Name: Gate Bool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &52
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 16.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &53
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &54
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &55
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 149f2d52b7a444a299d141a16b7bd8b4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+
+--- !u!1 &56
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 57}
+  - component: {fileID: 58}
+  - component: {fileID: 59}
+  - component: {fileID: 60}
+  m_Layer: 0
+  m_Name: Prompt Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &57
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 18.0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &58
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByComposite: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.75
+--- !u!114 &59
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dab57e84a84d304792c821754b09882, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  requiredActor: 0
+  interactionType: 0
+  range: 1.2
+  priority: 0
+  holdDurationMs: 1000
+  cooldownMs: 300
+  isLocked: 0
+  persistent: 0
+  OnFocusEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFocusExit:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractStart:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractProgress:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractComplete:
+    m_PersistentCalls:
+      m_Calls: []
+  OnInteractCancel:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &60
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b62dd005acfd43b48a0df333ff13aa64, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Scenes/InteractionDemo.unity.meta
+++ b/Assets/Scenes/InteractionDemo.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3223c9d698284f9aa93b84b556bfca71
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions.meta
+++ b/Assets/Scripts/Interactions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3bd2eace408d468d8ce6d723a80b175d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions.meta
+++ b/Assets/Scripts/Interactions/Actions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58dd517cddf643f89ab521453e74d74f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/BridgeExtendAction.cs
+++ b/Assets/Scripts/Interactions/Actions/BridgeExtendAction.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Bridge Extend Action")]
+public class BridgeExtendAction : InteractActionBase
+{
+    [Header("Bridge")]
+    [SerializeField] Transform bridgeRoot;
+    [SerializeField] Collider2D bridgeCollider;
+    [SerializeField] bool startExtended;
+
+    bool extended;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        extended = startExtended;
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        extended = !extended;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(bridgeRoot, extended);
+        InteractUtils.SetColliderPassable(bridgeCollider, extended);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/BridgeExtendAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/BridgeExtendAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30e598f03e7e48a99d015c1c5adb36af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/CameraShakeAction.cs
+++ b/Assets/Scripts/Interactions/Actions/CameraShakeAction.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using Cinemachine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Camera Shake Action")]
+public class CameraShakeAction : InteractActionBase
+{
+    [Header("Camera Shake")]
+    [SerializeField] CinemachineImpulseSource impulseSource;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (impulseSource)
+        {
+            impulseSource.GenerateImpulse();
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/CameraShakeAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/CameraShakeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a8945d8ddba4b43ad59c41757897a90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/CheckpointAction.cs
+++ b/Assets/Scripts/Interactions/Actions/CheckpointAction.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Checkpoint Action")]
+public class CheckpointAction : InteractActionBase
+{
+    [System.Serializable]
+    public class CheckpointEvent : UnityEvent<Vector3> { }
+
+    [Header("Checkpoint")]
+    [SerializeField] Transform spawnPoint;
+    [SerializeField] CheckpointEvent onCheckpointReached = new CheckpointEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        Vector3 position = spawnPoint ? spawnPoint.position : transform.position;
+        onCheckpointReached.Invoke(position);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/CheckpointAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/CheckpointAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8ea6b2ed86342128264badb91e2b0fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ChoiceAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ChoiceAction.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Choice Action")]
+public class ChoiceAction : InteractActionBase
+{
+    [System.Serializable]
+    public class ChoiceSelectedEvent : UnityEvent<int> { }
+
+    [Header("Choice UI")]
+    [SerializeField] CanvasGroup choiceCanvas;
+    [SerializeField] string gateFlagName = "Choice/Selection";
+    [SerializeField] ChoiceSelectedEvent onChoiceSelected = new ChoiceSelectedEvent();
+
+    bool open;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        open = true;
+        ApplyState();
+    }
+
+    public void HandleChoice(int index)
+    {
+        if (!open)
+            return;
+
+        InteractionStateStore.SetFlag(gateFlagName, index == 0);
+        onChoiceSelected.Invoke(index);
+        open = false;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        if (choiceCanvas)
+        {
+            InteractUtils.SetCanvasGroupVisible(choiceCanvas, open);
+        }
+    }
+
+    protected override void OnDisable()
+    {
+        base.OnDisable();
+        open = false;
+        ApplyState();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ChoiceAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ChoiceAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9108024a0634a98937863929b57487f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/CircuitPatchAction.cs
+++ b/Assets/Scripts/Interactions/Actions/CircuitPatchAction.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Circuit Patch Action")]
+public class CircuitPatchAction : InteractActionBase
+{
+    [Header("Circuit")]
+    [SerializeField] Renderer[] glowRenderers;
+    [SerializeField] Color onColor = Color.cyan;
+    [SerializeField] Color offColor = Color.gray;
+
+    bool active;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        active = !active;
+        ApplyState();
+    }
+
+    static readonly int colorProperty = Shader.PropertyToID("_Color");
+    static readonly MaterialPropertyBlock propertyBlock = new MaterialPropertyBlock();
+
+    void ApplyState()
+    {
+        if (glowRenderers == null)
+            return;
+
+        Color color = active ? onColor : offColor;
+        for (int i = 0; i < glowRenderers.Length; i++)
+        {
+            var renderer = glowRenderers[i];
+            if (!renderer)
+                continue;
+            propertyBlock.Clear();
+            renderer.GetPropertyBlock(propertyBlock);
+            propertyBlock.SetColor(colorProperty, color);
+            renderer.SetPropertyBlock(propertyBlock);
+            renderer.enabled = true;
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/CircuitPatchAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/CircuitPatchAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dff31217e50e4f05880d88f457200894
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ColorKeyAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ColorKeyAction.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Color Key Action")]
+public class ColorKeyAction : InteractActionBase
+{
+    [Header("Key Settings")]
+    [SerializeField] string requiredKeyId;
+    [SerializeField] Transform unlockedVisual;
+    [SerializeField] Transform lockedVisual;
+    [SerializeField] AudioSource successAudio;
+    [SerializeField] AudioSource failureAudio;
+
+    bool unlocked;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        unlocked = CheckKey(controller);
+        ApplyState();
+    }
+
+    bool CheckKey(InteractionController controller)
+    {
+        if (!controller)
+            return false;
+        var keyRing = controller.GetComponent<ColorKeyRing>();
+        if (!keyRing)
+            return false;
+        bool success = string.IsNullOrEmpty(requiredKeyId) || keyRing.CurrentKeyId == requiredKeyId;
+        if (success)
+        {
+            if (successAudio)
+                successAudio.Play();
+        }
+        else if (failureAudio)
+        {
+            failureAudio.Play();
+        }
+        return success;
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(unlockedVisual, unlocked);
+        InteractUtils.SetActiveSafe(lockedVisual, !unlocked);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ColorKeyAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ColorKeyAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1f4a1d182f24d109afdf35217199968
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/CounterAction.cs
+++ b/Assets/Scripts/Interactions/Actions/CounterAction.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Counter Action")]
+public class CounterAction : InteractActionBase
+{
+    [Header("Counter")]
+    [SerializeField] string counterName = "Counter/Generic";
+    [SerializeField] int targetCount = 3;
+    [SerializeField] UnityEvent onThresholdReached = new UnityEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        int value = InteractionStateStore.IncrementCounter(counterName);
+        if (value >= targetCount)
+        {
+            onThresholdReached.Invoke();
+        }
+    }
+
+    public void ResetCounter()
+    {
+        InteractionStateStore.ResetCounter(counterName);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/CounterAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/CounterAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 655677e4fce24bc8bd15999df2a7e5e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/CutsceneTriggerAction.cs
+++ b/Assets/Scripts/Interactions/Actions/CutsceneTriggerAction.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using UnityEngine.Playables;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Cutscene Trigger Action")]
+public class CutsceneTriggerAction : InteractActionBase
+{
+    [Header("Cutscene")]
+    [SerializeField] PlayableDirector playableDirector;
+    [SerializeField] bool restartIfPlaying = true;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (!playableDirector)
+            return;
+
+        if (playableDirector.state == PlayState.Playing)
+        {
+            if (restartIfPlaying)
+            {
+                playableDirector.time = 0d;
+                playableDirector.Play();
+            }
+        }
+        else
+        {
+            playableDirector.Play();
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/CutsceneTriggerAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/CutsceneTriggerAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06cf138e60684b2a836a798632650291
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/DialogueAction.cs
+++ b/Assets/Scripts/Interactions/Actions/DialogueAction.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Dialogue Action")]
+public class DialogueAction : InteractActionBase
+{
+    [System.Serializable]
+    public class DialogueEvent : UnityEvent<string> { }
+
+    [Header("Dialogue")]
+    [SerializeField] string dialogueId = "Dialogue/Intro";
+    [SerializeField] DialogueEvent onDialogueStart = new DialogueEvent();
+    [SerializeField] DialogueEvent onDialogueAdvance = new DialogueEvent();
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        onDialogueStart.Invoke(dialogueId);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        onDialogueAdvance.Invoke(dialogueId);
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        onDialogueAdvance.Invoke(string.Empty);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/DialogueAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/DialogueAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e3580595720403f8b69e4764ce6d867
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/DoorAction.cs
+++ b/Assets/Scripts/Interactions/Actions/DoorAction.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Door Action")]
+public class DoorAction : InteractActionBase
+{
+    [Header("Door Setup")]
+    [Tooltip("Optional closed state root.")]
+    [SerializeField] Transform closedVisual;
+    [Tooltip("Optional open state root.")]
+    [SerializeField] Transform openVisual;
+    [SerializeField] Collider2D blockingCollider;
+    [Tooltip("Optional animator controlling an 'Open' bool parameter.")]
+    [SerializeField] Animator animator;
+    [SerializeField] string openBoolName = "Open";
+    [SerializeField] bool startOpen;
+
+    bool isOpen;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        isOpen = startOpen;
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        isOpen = !isOpen;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(openVisual, isOpen);
+        InteractUtils.SetActiveSafe(closedVisual, !isOpen);
+        InteractUtils.SetColliderPassable(blockingCollider, isOpen);
+        if (animator && !string.IsNullOrEmpty(openBoolName))
+        {
+            animator.SetBool(openBoolName, isOpen);
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/DoorAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/DoorAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7452430735f419d92aff8e87ef1ffac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ElevatorCallAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ElevatorCallAction.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Elevator Call Action")]
+public class ElevatorCallAction : InteractActionBase
+{
+    [Header("Elevator Call")]
+    [SerializeField] Animator targetAnimator;
+    [SerializeField] string triggerName = "Call";
+    [Tooltip("Optional audio clip for the elevator call.")]
+    [SerializeField] AudioSource callAudio;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (targetAnimator && !string.IsNullOrEmpty(triggerName))
+        {
+            targetAnimator.SetTrigger(triggerName);
+        }
+        if (callAudio)
+        {
+            callAudio.Play();
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ElevatorCallAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ElevatorCallAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29f7d6c07a324788b3a99b848f65c123
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/FlickerAction.cs
+++ b/Assets/Scripts/Interactions/Actions/FlickerAction.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Flicker Action")]
+public class FlickerAction : InteractActionBase
+{
+    [Header("Flicker")]
+    [SerializeField] Light targetLight;
+    [SerializeField] Renderer[] renderers;
+    [SerializeField] float intervalMs = 120f;
+
+    bool flickering;
+    bool state;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+        ApplyState(false);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        BeginFlicker();
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        EndFlicker();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        EndFlicker();
+    }
+
+    void BeginFlicker()
+    {
+        if (flickering)
+            return;
+        flickering = true;
+        state = true;
+        ApplyState(state);
+        float interval = Mathf.Max(0.01f, intervalMs * 0.001f);
+        InvokeRepeating(nameof(Toggle), interval, interval);
+    }
+
+    void EndFlicker()
+    {
+        if (!flickering)
+            return;
+        flickering = false;
+        CancelInvoke(nameof(Toggle));
+        state = true;
+        ApplyState(state);
+    }
+
+    void Toggle()
+    {
+        state = !state;
+        ApplyState(state);
+    }
+
+    void ApplyState(bool enabled)
+    {
+        if (targetLight)
+        {
+            InteractUtils.SetLightEnabled(targetLight, enabled);
+        }
+        if (renderers != null)
+        {
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                InteractUtils.SetRendererEnabled(renderers[i], enabled);
+            }
+        }
+    }
+
+    protected override void OnDisable()
+    {
+        EndFlicker();
+        base.OnDisable();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/FlickerAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/FlickerAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a81447882f874e0fa8db4ccd2e7d177e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/GateBoolAction.cs
+++ b/Assets/Scripts/Interactions/Actions/GateBoolAction.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Gate Bool Action")]
+public class GateBoolAction : InteractActionBase
+{
+    [Header("Gate Bool")]
+    [SerializeField] string flagName = "Gate/Flag";
+    [SerializeField] bool valueOnComplete = true;
+    [SerializeField] bool resetOnCancel = true;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        if (resetOnCancel)
+        {
+            InteractionStateStore.SetFlag(flagName, false);
+        }
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        InteractionStateStore.SetFlag(flagName, valueOnComplete);
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        if (resetOnCancel)
+        {
+            InteractionStateStore.SetFlag(flagName, false);
+        }
+    }
+
+    public bool GetFlag()
+    {
+        return InteractionStateStore.GetFlag(flagName);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/GateBoolAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/GateBoolAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 149f2d52b7a444a299d141a16b7bd8b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/GizmoPulseAction.cs
+++ b/Assets/Scripts/Interactions/Actions/GizmoPulseAction.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Gizmo Pulse Action")]
+public class GizmoPulseAction : InteractActionBase
+{
+    [Header("Pulse")]
+    [SerializeField] Transform pulseGraphic;
+    [SerializeField] float focusedScale = 1.2f;
+    [SerializeField] float unfocusedScale = 1f;
+
+    UnityAction<InteractionController> focusEnterHandler;
+    UnityAction<InteractionController> focusExitHandler;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(false, false, false, false);
+        focusEnterHandler = _ => ApplyScale(focusedScale);
+        focusExitHandler = _ => ApplyScale(unfocusedScale);
+        ApplyScale(unfocusedScale);
+    }
+
+    protected override void OnEnable()
+    {
+        base.OnEnable();
+        var interactable = Target;
+        if (interactable != null)
+        {
+            interactable.OnFocusEnter.AddListener(focusEnterHandler);
+            interactable.OnFocusExit.AddListener(focusExitHandler);
+        }
+    }
+
+    protected override void OnDisable()
+    {
+        var interactable = Target;
+        if (interactable != null)
+        {
+            interactable.OnFocusEnter.RemoveListener(focusEnterHandler);
+            interactable.OnFocusExit.RemoveListener(focusExitHandler);
+        }
+        ApplyScale(unfocusedScale);
+        base.OnDisable();
+    }
+
+    void ApplyScale(float scale)
+    {
+        if (!pulseGraphic)
+            return;
+        pulseGraphic.localScale = Vector3.one * scale;
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/GizmoPulseAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/GizmoPulseAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4098dd19c9a1448da309fbe74c80eb6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/LightToggleAction.cs
+++ b/Assets/Scripts/Interactions/Actions/LightToggleAction.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Light Toggle Action")]
+public class LightToggleAction : InteractActionBase
+{
+    [Header("Light Toggle")]
+    [SerializeField] Light targetLight;
+    [SerializeField] float onIntensity = 1f;
+    [SerializeField] float offIntensity = 0f;
+    [SerializeField] bool startOn = true;
+
+    bool isOn;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        isOn = startOn;
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        isOn = !isOn;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        if (!targetLight)
+            return;
+
+        InteractUtils.SetLightEnabled(targetLight, isOn);
+        targetLight.intensity = isOn ? onIntensity : offIntensity;
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/LightToggleAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/LightToggleAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df7a3da0686440238400658e8a0ecd32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/LogEventAction.cs
+++ b/Assets/Scripts/Interactions/Actions/LogEventAction.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEngine.Profiling;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Log Event Action")]
+public class LogEventAction : InteractActionBase
+{
+    static readonly ProfilerMarker startMarker = new ProfilerMarker("Interaction.Start");
+    static readonly ProfilerMarker progressMarker = new ProfilerMarker("Interaction.Progress");
+    static readonly ProfilerMarker completeMarker = new ProfilerMarker("Interaction.Complete");
+    static readonly ProfilerMarker cancelMarker = new ProfilerMarker("Interaction.Cancel");
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, true, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        using (startMarker.Auto())
+        {
+            Debug.Log($"Interaction start: {name}");
+        }
+    }
+
+    protected override void OnProgress(float value)
+    {
+        using (progressMarker.Auto())
+        {
+            Debug.Log($"Interaction progress {name}: {value:0.00}");
+        }
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        using (completeMarker.Auto())
+        {
+            Debug.Log($"Interaction complete: {name}");
+        }
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        using (cancelMarker.Auto())
+        {
+            Debug.Log($"Interaction cancel: {name}");
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/LogEventAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/LogEventAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7af4b4be6c6445b29a574b98a45ce0be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/LogPickupAction.cs
+++ b/Assets/Scripts/Interactions/Actions/LogPickupAction.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Log Pickup Action")]
+public class LogPickupAction : InteractActionBase
+{
+    [System.Serializable]
+    public class LogEvent : UnityEvent<string> { }
+
+    [Header("Log Pickup")]
+    [SerializeField] string logId = "Lore/Entry01";
+    [SerializeField] LogEvent onLogCollected = new LogEvent();
+    [SerializeField] Transform collectedVisual;
+    [SerializeField] Transform availableVisual;
+
+    bool collected;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (collected)
+            return;
+        collected = true;
+        onLogCollected.Invoke(logId);
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(collectedVisual, collected);
+        InteractUtils.SetActiveSafe(availableVisual, !collected);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/LogPickupAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/LogPickupAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35d90a8ab5cf40afbe4ad179751c9ea0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/MemoryFlashAction.cs
+++ b/Assets/Scripts/Interactions/Actions/MemoryFlashAction.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Memory Flash Action")]
+public class MemoryFlashAction : InteractActionBase
+{
+    [Header("Memory Flash")]
+    [SerializeField] Animator flashAnimator;
+    [SerializeField] string triggerName = "Flash";
+    [SerializeField] Text messageText;
+    [SerializeField] string message;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (flashAnimator && !string.IsNullOrEmpty(triggerName))
+        {
+            flashAnimator.SetTrigger(triggerName);
+        }
+        if (messageText)
+        {
+            messageText.text = message;
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/MemoryFlashAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/MemoryFlashAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd176017ccc64d219637a431ae1caaa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/MovingDoorAction.cs
+++ b/Assets/Scripts/Interactions/Actions/MovingDoorAction.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Moving Door Action")]
+public class MovingDoorAction : InteractActionBase
+{
+    [Header("Moving Door")]
+    [SerializeField] Animator animator;
+    [SerializeField] string openBoolName = "Open";
+    [SerializeField] string callTriggerName = string.Empty;
+    [Tooltip("Optional transform moved directly when no animator is supplied.")]
+    [SerializeField] Transform movingRoot;
+    [SerializeField] Vector3 closedLocalPosition;
+    [SerializeField] Vector3 openLocalPosition;
+
+    bool isOpen;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+        ApplyState(false);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        isOpen = true;
+        ApplyState(true);
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        isOpen = false;
+        ApplyState(true);
+    }
+
+    void ApplyState(bool animate)
+    {
+        if (animator)
+        {
+            if (!string.IsNullOrEmpty(openBoolName))
+            {
+                animator.SetBool(openBoolName, isOpen);
+            }
+            if (animate && !string.IsNullOrEmpty(callTriggerName))
+            {
+                animator.SetTrigger(callTriggerName);
+            }
+        }
+        else if (movingRoot)
+        {
+            movingRoot.localPosition = isOpen ? openLocalPosition : closedLocalPosition;
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/MovingDoorAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/MovingDoorAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd6887d1946b45059e88c8949bbca83a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/MultiGateAction.cs
+++ b/Assets/Scripts/Interactions/Actions/MultiGateAction.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Multi Gate Action")]
+public class MultiGateAction : InteractActionBase
+{
+    [Header("Multi Gate")]
+    [SerializeField] string[] requiredFlags;
+    [SerializeField] UnityEvent onAllTrue = new UnityEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (AllFlagsTrue())
+        {
+            onAllTrue.Invoke();
+        }
+    }
+
+    bool AllFlagsTrue()
+    {
+        if (requiredFlags == null || requiredFlags.Length == 0)
+            return true;
+        for (int i = 0; i < requiredFlags.Length; i++)
+        {
+            if (!InteractionStateStore.GetFlag(requiredFlags[i]))
+                return false;
+        }
+        return true;
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/MultiGateAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/MultiGateAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c38c22f0da754726a0931f5172632d84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/MusicSnapshotAction.cs
+++ b/Assets/Scripts/Interactions/Actions/MusicSnapshotAction.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.Audio;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Music Snapshot Action")]
+public class MusicSnapshotAction : InteractActionBase
+{
+    [Header("Music Snapshot")]
+    [SerializeField] AudioMixerSnapshot snapshot;
+    [SerializeField] float transitionTime = 0.5f;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (snapshot)
+        {
+            snapshot.TransitionTo(Mathf.Max(0f, transitionTime));
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/MusicSnapshotAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/MusicSnapshotAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 037f1526271049ae8da8538a3941e341
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ParticleBurstAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ParticleBurstAction.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Particle Burst Action")]
+public class ParticleBurstAction : InteractActionBase
+{
+    [Header("Particles")]
+    [SerializeField] ParticleSystem particleSystem;
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        InteractUtils.PlayParticleSafe(particleSystem);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ParticleBurstAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ParticleBurstAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fe88d8ca0b0481f97723a2ec47096a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/PlatformToggleAction.cs
+++ b/Assets/Scripts/Interactions/Actions/PlatformToggleAction.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Platform Toggle Action")]
+public class PlatformToggleAction : InteractActionBase
+{
+    [Header("Platform Toggle")]
+    [SerializeField] Transform targetRoot;
+    [SerializeField] bool startEnabled = true;
+
+    bool isEnabled;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        isEnabled = startEnabled;
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        isEnabled = !isEnabled;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(targetRoot, isEnabled);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/PlatformToggleAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/PlatformToggleAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05636028c5c047699cd627f261e14c93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/PromptHintAction.cs
+++ b/Assets/Scripts/Interactions/Actions/PromptHintAction.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Prompt Hint Action")]
+public class PromptHintAction : InteractActionBase
+{
+    [Header("Prompt Hint")]
+    [SerializeField] CanvasGroup worldSpaceHint;
+    [SerializeField] CanvasGroup screenSpaceHint;
+
+    UnityAction<InteractionController> focusEnterHandler;
+    UnityAction<InteractionController> focusExitHandler;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(false, false, false, false);
+        focusEnterHandler = HandleFocusEnter;
+        focusExitHandler = HandleFocusExit;
+        ApplyVisibility(false);
+    }
+
+    protected override void OnEnable()
+    {
+        base.OnEnable();
+        var interactable = Target;
+        if (interactable != null)
+        {
+            interactable.OnFocusEnter.AddListener(focusEnterHandler);
+            interactable.OnFocusExit.AddListener(focusExitHandler);
+        }
+    }
+
+    protected override void OnDisable()
+    {
+        var interactable = Target;
+        if (interactable != null)
+        {
+            interactable.OnFocusEnter.RemoveListener(focusEnterHandler);
+            interactable.OnFocusExit.RemoveListener(focusExitHandler);
+        }
+        ApplyVisibility(false);
+        base.OnDisable();
+    }
+
+    void HandleFocusEnter(InteractionController controller)
+    {
+        ApplyVisibility(true);
+    }
+
+    void HandleFocusExit(InteractionController controller)
+    {
+        ApplyVisibility(false);
+    }
+
+    void ApplyVisibility(bool visible)
+    {
+        InteractUtils.SetCanvasGroupVisible(worldSpaceHint, visible);
+        InteractUtils.SetCanvasGroupVisible(screenSpaceHint, visible);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/PromptHintAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/PromptHintAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b62dd005acfd43b48a0df333ff13aa64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/QuestAdvanceAction.cs
+++ b/Assets/Scripts/Interactions/Actions/QuestAdvanceAction.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Quest Advance Action")]
+public class QuestAdvanceAction : InteractActionBase
+{
+    [System.Serializable]
+    public class QuestEvent : UnityEvent<string> { }
+
+    [Header("Quest")]
+    [SerializeField] string questId = "MainQuest";
+    [SerializeField] int step = 1;
+    [SerializeField] QuestEvent onQuestAdvance = new QuestEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        onQuestAdvance.Invoke(questId + ":" + step);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/QuestAdvanceAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/QuestAdvanceAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2def808622b2444487d8c88555385f52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ReticleSnapAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ReticleSnapAction.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Reticle Snap Action")]
+public class ReticleSnapAction : InteractActionBase
+{
+    [System.Serializable]
+    public class ReticleLockEvent : UnityEvent<Transform> { }
+
+    [Header("Reticle Snap")]
+    [SerializeField] Transform snapTarget;
+    [SerializeField] ReticleLockEvent onLock = new ReticleLockEvent();
+    [SerializeField] UnityEvent onRelease = new UnityEvent();
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        onLock.Invoke(snapTarget ? snapTarget : transform);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        onRelease.Invoke();
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        onRelease.Invoke();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ReticleSnapAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ReticleSnapAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19f10a58b26b4ee993d61614cffc927e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/SaveGameAction.cs
+++ b/Assets/Scripts/Interactions/Actions/SaveGameAction.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Save Game Action")]
+public class SaveGameAction : InteractActionBase
+{
+    [Header("Save Game")]
+    [SerializeField] UnityEvent onSaveRequested = new UnityEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        onSaveRequested.Invoke();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/SaveGameAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/SaveGameAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cf8df24269649be95fb44e10c6fb9fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ScreenFadeAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ScreenFadeAction.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Screen Fade Action")]
+public class ScreenFadeAction : InteractActionBase
+{
+    [Header("Screen Fade")]
+    [SerializeField] CanvasGroup canvasGroup;
+    [SerializeField] float startAlpha = 0f;
+    [SerializeField] float endAlpha = 1f;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+        ApplyAlpha(startAlpha);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        ApplyAlpha(endAlpha);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        ApplyAlpha(endAlpha);
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        ApplyAlpha(startAlpha);
+    }
+
+    void ApplyAlpha(float alpha)
+    {
+        if (!canvasGroup)
+            return;
+        canvasGroup.alpha = Mathf.Clamp01(alpha);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ScreenFadeAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ScreenFadeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d0f84f9692546e8a6f1ae9ef23e6971
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/SequencePadAction.cs
+++ b/Assets/Scripts/Interactions/Actions/SequencePadAction.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.Events;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Sequence Pad Action")]
+public class SequencePadAction : InteractActionBase
+{
+    [System.Serializable]
+    public class SequenceEvent : UnityEvent<int> { }
+
+    [Header("Sequence Pad")]
+    [SerializeField] int stepId = 1;
+    [SerializeField] SequenceEvent onSequenceStep = new SequenceEvent();
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        onSequenceStep.Invoke(stepId);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/SequencePadAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/SequencePadAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 947abf2afbbf498586797ce183650080
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/SfxAction.cs
+++ b/Assets/Scripts/Interactions/Actions/SfxAction.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/SFX Action")]
+public class SfxAction : InteractActionBase
+{
+    [Header("Sound Effects")]
+    [SerializeField] AudioSource onStart;
+    [SerializeField] AudioSource onComplete;
+    [SerializeField] AudioSource onCancel;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        Play(onStart);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        Play(onComplete);
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        Play(onCancel);
+    }
+
+    void Play(AudioSource source)
+    {
+        if (!source)
+            return;
+        source.Play();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/SfxAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/SfxAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4cdbc1d361e4a3e896cb61c13e7388a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/SlowTimeAction.cs
+++ b/Assets/Scripts/Interactions/Actions/SlowTimeAction.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Slow Time Action")]
+public class SlowTimeAction : InteractActionBase
+{
+    [Header("Slow Time")]
+    [SerializeField] float timeScale = 0.5f;
+    [SerializeField] bool restoreOnComplete = true;
+
+    float defaultTimeScale = 1f;
+    bool applied;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        Apply();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        if (restoreOnComplete)
+            Restore();
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        Restore();
+    }
+
+    void Apply()
+    {
+        if (applied)
+            return;
+        defaultTimeScale = Time.timeScale;
+        Time.timeScale = Mathf.Max(0.01f, timeScale);
+        applied = true;
+    }
+
+    void Restore()
+    {
+        if (!applied)
+            return;
+        Time.timeScale = defaultTimeScale;
+        applied = false;
+    }
+
+    protected override void OnDisable()
+    {
+        Restore();
+        base.OnDisable();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/SlowTimeAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/SlowTimeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a733a67f61b444c694ca3a174306e246
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/TimeLeverAction.cs
+++ b/Assets/Scripts/Interactions/Actions/TimeLeverAction.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Time Lever Action")]
+public class TimeLeverAction : InteractActionBase
+{
+    [Header("Time Lever")]
+    [SerializeField] float slowFactor = 0.25f;
+    [SerializeField] bool affectFixedDeltaTime = true;
+
+    float defaultTimeScale = 1f;
+    float defaultFixedDeltaTime;
+    bool applied;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, false, true, true);
+        defaultFixedDeltaTime = Time.fixedDeltaTime;
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        ApplyTimeScale();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        RestoreTimeScale();
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        RestoreTimeScale();
+    }
+
+    void ApplyTimeScale()
+    {
+        if (applied)
+            return;
+
+        defaultTimeScale = Time.timeScale;
+        Time.timeScale = Mathf.Max(0.01f, slowFactor);
+        if (affectFixedDeltaTime)
+            Time.fixedDeltaTime = defaultFixedDeltaTime * Time.timeScale;
+        applied = true;
+    }
+
+    void RestoreTimeScale()
+    {
+        if (!applied)
+            return;
+
+        Time.timeScale = defaultTimeScale;
+        if (affectFixedDeltaTime)
+            Time.fixedDeltaTime = defaultFixedDeltaTime;
+        applied = false;
+    }
+
+    protected override void OnDisable()
+    {
+        RestoreTimeScale();
+        base.OnDisable();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/TimeLeverAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/TimeLeverAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4225440b92394519ae6f0bb52ff343ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/TimedSwitchAction.cs
+++ b/Assets/Scripts/Interactions/Actions/TimedSwitchAction.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Timed Switch Action")]
+public class TimedSwitchAction : InteractActionBase
+{
+    [Header("Timed Switch")]
+    [SerializeField] Transform activeRoot;
+    [SerializeField] Transform inactiveRoot;
+    [SerializeField] float durationMs = 2000f;
+
+    bool isActive;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        ApplyState();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        isActive = true;
+        ApplyState();
+        CancelInvoke(nameof(TurnOff));
+        if (durationMs > 0f)
+        {
+            Invoke(nameof(TurnOff), durationMs * 0.001f);
+        }
+    }
+
+    void TurnOff()
+    {
+        isActive = false;
+        ApplyState();
+    }
+
+    void ApplyState()
+    {
+        InteractUtils.SetActiveSafe(activeRoot, isActive);
+        InteractUtils.SetActiveSafe(inactiveRoot, !isActive);
+    }
+
+    protected override void OnDisable()
+    {
+        CancelInvoke(nameof(TurnOff));
+        base.OnDisable();
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/TimedSwitchAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/TimedSwitchAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5e149ddbd7045fcb608afe083627bc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/ValveAction.cs
+++ b/Assets/Scripts/Interactions/Actions/ValveAction.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Valve Action")]
+public class ValveAction : InteractActionBase
+{
+    [Header("Valve")]
+    [SerializeField] Transform valveRoot;
+    [SerializeField] float maxAngle = 180f;
+    [SerializeField] bool resetOnCancel = true;
+
+    float currentValue;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetEventListening(true, true, true, true);
+    }
+
+    protected override void OnStart(InteractionController controller)
+    {
+        currentValue = 0f;
+        ApplyRotation();
+    }
+
+    protected override void OnProgress(float value)
+    {
+        currentValue = Mathf.Clamp01(value);
+        ApplyRotation();
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        currentValue = 1f;
+        ApplyRotation();
+    }
+
+    protected override void OnCancel(InteractionController controller)
+    {
+        if (resetOnCancel)
+        {
+            currentValue = 0f;
+            ApplyRotation();
+        }
+    }
+
+    void ApplyRotation()
+    {
+        if (!valveRoot)
+            return;
+        valveRoot.localRotation = Quaternion.Euler(0f, 0f, -maxAngle * currentValue);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/ValveAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/ValveAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1c5172804ec49f8bad1d49a35458e0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Actions/WeightCheckAction.cs
+++ b/Assets/Scripts/Interactions/Actions/WeightCheckAction.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using Interactions.Core;
+
+[RequireComponent(typeof(Interactable))]
+[AddComponentMenu("Interactions/Actions/Weight Check Action")]
+public class WeightCheckAction : InteractActionBase
+{
+    [Header("Weight Check")]
+    [SerializeField] Collider2D checkArea;
+    [SerializeField] float requiredMass = 10f;
+    [SerializeField] LayerMask massMask = ~0;
+    [SerializeField] Transform passedVisual;
+    [SerializeField] Transform failedVisual;
+
+    static readonly Collider2D[] overlapBuffer = new Collider2D[16];
+    readonly ContactFilter2D contactFilter = new ContactFilter2D();
+
+    protected override void Awake()
+    {
+        base.Awake();
+        contactFilter.useLayerMask = true;
+        contactFilter.layerMask = massMask;
+        contactFilter.useTriggers = true;
+        ApplyState(false);
+    }
+
+    protected override void OnComplete(InteractionController controller)
+    {
+        bool success = CheckMass();
+        ApplyState(success);
+    }
+
+    bool CheckMass()
+    {
+        if (!checkArea)
+            return false;
+
+        int count = checkArea.OverlapCollider(contactFilter, overlapBuffer);
+        float totalMass = 0f;
+        for (int i = 0; i < count; i++)
+        {
+            var collider = overlapBuffer[i];
+            if (!collider)
+                continue;
+            var body = collider.attachedRigidbody;
+            if (!body)
+                continue;
+            totalMass += body.mass;
+        }
+        return totalMass >= requiredMass;
+    }
+
+    void ApplyState(bool success)
+    {
+        InteractUtils.SetActiveSafe(passedVisual, success);
+        InteractUtils.SetActiveSafe(failedVisual, !success);
+    }
+}

--- a/Assets/Scripts/Interactions/Actions/WeightCheckAction.cs.meta
+++ b/Assets/Scripts/Interactions/Actions/WeightCheckAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a74c1a08ade746da8aeb0d6be9149651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core.meta
+++ b/Assets/Scripts/Interactions/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac1db1a03bb14e079b80624bf0add6f5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core/ColorKeyRing.cs
+++ b/Assets/Scripts/Interactions/Core/ColorKeyRing.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace Interactions.Core
+{
+    public class ColorKeyRing : MonoBehaviour
+    {
+        [Tooltip("Key identifier currently held by this actor.")]
+        [SerializeField] string currentKeyId;
+
+        public string CurrentKeyId => currentKeyId;
+
+        public void SetKey(string keyId)
+        {
+            currentKeyId = keyId;
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Core/ColorKeyRing.cs.meta
+++ b/Assets/Scripts/Interactions/Core/ColorKeyRing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cc4edfb41f54bdb99025a5a2b622d10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core/InteractActionBase.cs
+++ b/Assets/Scripts/Interactions/Core/InteractActionBase.cs
@@ -1,0 +1,167 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Interactions.Core
+{
+    public abstract class InteractActionBase : MonoBehaviour
+    {
+        [Header("Interaction Target")]
+        [Tooltip("Interactable component that raises the events this action listens to.")]
+        [SerializeField] Interactable target;
+
+        [Header("Event Binding")]
+        [SerializeField] bool listenOnStart = true;
+        [SerializeField] bool listenOnProgress = false;
+        [SerializeField] bool listenOnComplete = true;
+        [SerializeField] bool listenOnCancel = false;
+
+        [Header("Actor Filter")]
+        [Tooltip("Override interaction actor required for this action to respond.")]
+        [SerializeField] bool overrideActorFilter = false;
+        [SerializeField] InteractionActor actorFilter = InteractionActor.Any;
+
+        [Header("Timing")]
+        [Tooltip("Optional local cooldown in milliseconds before the action can fire again.")]
+        [SerializeField] float localCooldownMs = 0f;
+
+        readonly UnityAction<InteractionController> startHandler;
+        readonly UnityAction<float> progressHandler;
+        readonly UnityAction<InteractionController> completeHandler;
+        readonly UnityAction<InteractionController> cancelHandler;
+
+        float nextAllowedTimeMs;
+
+        protected InteractActionBase()
+        {
+            startHandler = HandleStart;
+            progressHandler = HandleProgress;
+            completeHandler = HandleComplete;
+            cancelHandler = HandleCancel;
+        }
+
+        protected virtual void Awake()
+        {
+            if (!target)
+            {
+                target = GetComponent<Interactable>();
+            }
+        }
+
+        protected virtual void OnValidate()
+        {
+            if (!target)
+            {
+                target = GetComponent<Interactable>();
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            if (!target)
+                target = GetComponent<Interactable>();
+
+            if (!target)
+                return;
+
+            if (listenOnStart)
+                target.OnInteractStart.AddListener(startHandler);
+            if (listenOnProgress)
+                target.OnInteractProgress.AddListener(progressHandler);
+            if (listenOnComplete)
+                target.OnInteractComplete.AddListener(completeHandler);
+            if (listenOnCancel)
+                target.OnInteractCancel.AddListener(cancelHandler);
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (!target)
+                return;
+
+            if (listenOnStart)
+                target.OnInteractStart.RemoveListener(startHandler);
+            if (listenOnProgress)
+                target.OnInteractProgress.RemoveListener(progressHandler);
+            if (listenOnComplete)
+                target.OnInteractComplete.RemoveListener(completeHandler);
+            if (listenOnCancel)
+                target.OnInteractCancel.RemoveListener(cancelHandler);
+        }
+
+        protected void SetEventListening(bool onStart, bool onProgress, bool onComplete, bool onCancel)
+        {
+            listenOnStart = onStart;
+            listenOnProgress = onProgress;
+            listenOnComplete = onComplete;
+            listenOnCancel = onCancel;
+        }
+
+        bool CanProcess(InteractionController controller)
+        {
+            if (!enabled || !target)
+                return false;
+
+            if (overrideActorFilter && actorFilter != InteractionActor.Any)
+            {
+                if (!controller || controller.actor != actorFilter)
+                    return false;
+            }
+
+            if (localCooldownMs > 0f)
+            {
+                float currentMs = Time.unscaledTime * 1000f;
+                if (currentMs < nextAllowedTimeMs)
+                    return false;
+            }
+
+            return true;
+        }
+
+        void StampCooldown()
+        {
+            if (localCooldownMs > 0f)
+            {
+                nextAllowedTimeMs = Time.unscaledTime * 1000f + localCooldownMs;
+            }
+        }
+
+        void HandleStart(InteractionController controller)
+        {
+            if (!CanProcess(controller))
+                return;
+            OnStart(controller);
+            StampCooldown();
+        }
+
+        void HandleProgress(float value)
+        {
+            if (!enabled || !target)
+                return;
+            OnProgress(value);
+        }
+
+        void HandleComplete(InteractionController controller)
+        {
+            if (!CanProcess(controller))
+                return;
+            OnComplete(controller);
+            StampCooldown();
+        }
+
+        void HandleCancel(InteractionController controller)
+        {
+            if (!CanProcess(controller))
+                return;
+            OnCancel(controller);
+        }
+
+        protected virtual void OnStart(InteractionController controller) { }
+        protected virtual void OnProgress(float value) { }
+        protected virtual void OnComplete(InteractionController controller) { }
+        protected virtual void OnCancel(InteractionController controller) { }
+
+        protected Interactable Target => target;
+        protected bool HasActorOverride => overrideActorFilter && actorFilter != InteractionActor.Any;
+        protected InteractionActor ActorFilter => actorFilter;
+    }
+}

--- a/Assets/Scripts/Interactions/Core/InteractActionBase.cs.meta
+++ b/Assets/Scripts/Interactions/Core/InteractActionBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44c86b22708b4eae9e74e0d381b6adc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core/InteractGizmos.cs
+++ b/Assets/Scripts/Interactions/Core/InteractGizmos.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace Interactions.Core
+{
+    [ExecuteAlways]
+    public class InteractGizmos : MonoBehaviour
+    {
+        [Tooltip("Optional custom color for the interaction gizmos.")]
+        public Color gizmoColor = new Color(0.25f, 0.9f, 1f, 0.75f);
+        [Tooltip("Optional focus color when the object is highlighted.")]
+        public Color focusColor = new Color(1f, 0.8f, 0.2f, 0.9f);
+
+        Interactable cachedInteractable;
+
+        void OnDrawGizmosSelected()
+        {
+            if (!cachedInteractable)
+                cachedInteractable = GetComponent<Interactable>();
+
+            if (!cachedInteractable)
+                return;
+
+            Vector3 position = cachedInteractable.transform.position;
+            float range = Mathf.Max(0.01f, cachedInteractable.range);
+
+            Gizmos.color = gizmoColor;
+            Gizmos.DrawWireSphere(position, range);
+
+            if (cachedInteractable.ToggleState)
+            {
+                Gizmos.color = focusColor;
+                Gizmos.DrawSphere(position, 0.05f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Core/InteractGizmos.cs.meta
+++ b/Assets/Scripts/Interactions/Core/InteractGizmos.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c8f23aab55245d9bb402a3a5f90b6f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core/InteractUtils.cs
+++ b/Assets/Scripts/Interactions/Core/InteractUtils.cs
@@ -1,0 +1,73 @@
+using UnityEngine;
+
+namespace Interactions.Core
+{
+    public static class InteractUtils
+    {
+        public static void SetActiveSafe(Transform target, bool value)
+        {
+            if (!target)
+                return;
+            if (target.gameObject.activeSelf != value)
+                target.gameObject.SetActive(value);
+        }
+
+        public static void SetRendererEnabled(Renderer renderer, bool value)
+        {
+            if (!renderer)
+                return;
+            if (renderer.enabled != value)
+                renderer.enabled = value;
+        }
+
+        public static void SetSpriteEnabled(SpriteRenderer renderer, bool value)
+        {
+            if (!renderer)
+                return;
+            if (renderer.enabled != value)
+                renderer.enabled = value;
+        }
+
+        public static void SetColliderPassable(Collider2D collider, bool passable)
+        {
+            if (!collider)
+                return;
+            if (collider.isTrigger != passable)
+                collider.isTrigger = passable;
+        }
+
+        public static void SetCanvasGroupVisible(CanvasGroup canvasGroup, bool visible, float alphaOn = 1f, float alphaOff = 0f)
+        {
+            if (!canvasGroup)
+                return;
+
+            canvasGroup.alpha = visible ? alphaOn : alphaOff;
+            canvasGroup.blocksRaycasts = visible;
+            canvasGroup.interactable = visible;
+        }
+
+        public static void PlayParticleSafe(ParticleSystem particles)
+        {
+            if (!particles)
+                return;
+            if (!particles.isPlaying)
+                particles.Play();
+        }
+
+        public static void StopParticleSafe(ParticleSystem particles)
+        {
+            if (!particles)
+                return;
+            if (particles.isPlaying)
+                particles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        }
+
+        public static void SetLightEnabled(Light light, bool value)
+        {
+            if (!light)
+                return;
+            if (light.enabled != value)
+                light.enabled = value;
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Core/InteractUtils.cs.meta
+++ b/Assets/Scripts/Interactions/Core/InteractUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acd2981baec0406e8d95af79992db1ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Core/InteractionStateStore.cs
+++ b/Assets/Scripts/Interactions/Core/InteractionStateStore.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace Interactions.Core
+{
+    public static class InteractionStateStore
+    {
+        static readonly Dictionary<string, bool> boolFlags = new Dictionary<string, bool>();
+        static readonly Dictionary<string, int> counters = new Dictionary<string, int>();
+
+        public static bool GetFlag(string key)
+        {
+            boolFlags.TryGetValue(key, out bool value);
+            return value;
+        }
+
+        public static void SetFlag(string key, bool value)
+        {
+            if (string.IsNullOrEmpty(key))
+                return;
+            boolFlags[key] = value;
+        }
+
+        public static void ClearFlag(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                return;
+            boolFlags.Remove(key);
+        }
+
+        public static int GetCounter(string key)
+        {
+            counters.TryGetValue(key, out int value);
+            return value;
+        }
+
+        public static int IncrementCounter(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                return 0;
+            int value = GetCounter(key) + 1;
+            counters[key] = value;
+            return value;
+        }
+
+        public static void ResetCounter(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                return;
+            counters.Remove(key);
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/Core/InteractionStateStore.cs.meta
+++ b/Assets/Scripts/Interactions/Core/InteractionStateStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2efd63c563354029a1dbafdaa868b95c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Editor.meta
+++ b/Assets/Scripts/Interactions/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fb7b4982ed945608fe9507f7d790c66
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Editor/InteractableEditor.cs
+++ b/Assets/Scripts/Interactions/Editor/InteractableEditor.cs
@@ -1,0 +1,71 @@
+using UnityEditor;
+using UnityEngine;
+using Interactions.Core;
+
+[CustomEditor(typeof(Interactable))]
+public class InteractableEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        var interactable = (Interactable)target;
+        if (!interactable)
+            return;
+
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Interaction Actions", EditorStyles.boldLabel);
+
+        var actions = interactable.GetComponents<InteractActionBase>();
+        if (actions.Length == 0)
+        {
+            EditorGUILayout.HelpBox("No InteractActionBase components attached. Add one to author modular behaviour.", MessageType.Info);
+        }
+        else
+        {
+            for (int i = 0; i < actions.Length; i++)
+            {
+                var action = actions[i];
+                if (!action)
+                    continue;
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.ObjectField(action.GetType().Name, action, action.GetType(), true);
+                    if (GUILayout.Button("Select", GUILayout.Width(60f)))
+                    {
+                        Selection.activeObject = action;
+                    }
+                }
+            }
+        }
+
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Quick Create", EditorStyles.boldLabel);
+
+        if (GUILayout.Button("Quick-Bind: Complete → DoorAction.Toggle()"))
+        {
+            EnsureAction<DoorAction>(interactable);
+        }
+        if (GUILayout.Button("Quick-Bind: Complete → PlatformToggleAction.Toggle()"))
+        {
+            EnsureAction<PlatformToggleAction>(interactable);
+        }
+        if (GUILayout.Button("Quick-Bind: Hold → DialogueAction"))
+        {
+            interactable.interactionType = InteractionType.Hold;
+            EnsureAction<DialogueAction>(interactable);
+        }
+    }
+
+    static void EnsureAction<T>(Interactable interactable) where T : Component
+    {
+        var action = interactable.GetComponent<T>();
+        if (!action)
+        {
+            action = interactable.gameObject.AddComponent<T>();
+            Undo.RegisterCreatedObjectUndo(action, "Add Interaction Action");
+        }
+        Selection.activeObject = action;
+        EditorUtility.SetDirty(interactable);
+    }
+}

--- a/Assets/Scripts/Interactions/Editor/InteractableEditor.cs.meta
+++ b/Assets/Scripts/Interactions/Editor/InteractableEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04ddd3ee20fe4b8791f27330f56040ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/Editor/InteractionPrefabMenu.cs
+++ b/Assets/Scripts/Interactions/Editor/InteractionPrefabMenu.cs
@@ -1,0 +1,63 @@
+using UnityEditor;
+using UnityEngine;
+
+public static class InteractionPrefabMenu
+{
+    [MenuItem("Tools/Interactions/Create/Door", priority = 10)]
+    static void CreateDoor()
+    {
+        var root = new GameObject("DoorInteraction");
+        Undo.RegisterCreatedObjectUndo(root, "Create Door Interaction");
+
+        var interactable = root.AddComponent<Interactable>();
+        interactable.interactionType = InteractionType.Toggle;
+
+        var collider = root.AddComponent<BoxCollider2D>();
+        collider.isTrigger = true;
+
+        var closed = new GameObject("Closed");
+        closed.transform.SetParent(root.transform, false);
+        var open = new GameObject("Open");
+        open.transform.SetParent(root.transform, false);
+
+        var door = root.AddComponent<DoorAction>();
+        var serializedDoor = new SerializedObject(door);
+        serializedDoor.FindProperty("closedVisual").objectReferenceValue = closed.transform;
+        serializedDoor.FindProperty("openVisual").objectReferenceValue = open.transform;
+        serializedDoor.FindProperty("blockingCollider").objectReferenceValue = collider;
+        serializedDoor.ApplyModifiedProperties();
+
+        Selection.activeGameObject = root;
+    }
+
+    [MenuItem("Tools/Interactions/Create/Moving Door", priority = 11)]
+    static void CreateMovingDoor()
+    {
+        var root = new GameObject("MovingDoorInteraction");
+        Undo.RegisterCreatedObjectUndo(root, "Create Moving Door Interaction");
+
+        var interactable = root.AddComponent<Interactable>();
+        interactable.interactionType = InteractionType.Toggle;
+
+        root.AddComponent<BoxCollider2D>().isTrigger = true;
+        root.AddComponent<MovingDoorAction>();
+
+        Selection.activeGameObject = root;
+    }
+
+    [MenuItem("Tools/Interactions/Create/Panel Trigger", priority = 12)]
+    static void CreatePanelTrigger()
+    {
+        var root = new GameObject("PanelTriggerInteraction");
+        Undo.RegisterCreatedObjectUndo(root, "Create Panel Trigger Interaction");
+
+        var interactable = root.AddComponent<Interactable>();
+        interactable.interactionType = InteractionType.Panel;
+        interactable.holdDurationMs = 1000f;
+
+        root.AddComponent<BoxCollider2D>().isTrigger = true;
+        root.AddComponent<SequencePadAction>();
+
+        Selection.activeGameObject = root;
+    }
+}

--- a/Assets/Scripts/Interactions/Editor/InteractionPrefabMenu.cs.meta
+++ b/Assets/Scripts/Interactions/Editor/InteractionPrefabMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 890bb0528cac4163a1374423aa17d5fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI.meta
+++ b/Assets/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0addb478860d46e4a7ccca2d8954f576
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Interactions.meta
+++ b/Assets/UI/Interactions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6892d03ebcbb42cc84adbbd1afe8148a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/Interactions.md
+++ b/Docs/Interactions.md
@@ -1,0 +1,95 @@
+# Interaction Action System
+
+This document outlines the modular interaction action graph introduced in the `feature/interaction-nodes` branch.
+
+## Overview
+
+Every interactive element in the scene exposes its hooks through the existing `Interactable` component. Designers attach one or more `InteractActionBase`-derived behaviours to respond to interaction events (Start, Progress, Complete, Cancel) without authoring new scripts.
+
+### Event Flow
+
+```
+InteractionController (player)
+   └── scans + focuses Interactable
+            └── raises UnityEvents:
+                • OnFocusEnter / Exit
+                • OnInteractStart / Progress / Complete / Cancel
+                        └── InteractActionBase listeners execute Action logic
+```
+
+The `InteractionController.Tick()` method already runs inside `AbilityController.Tick()` to keep the system event-driven—no new `Update()` loops were introduced.
+
+## Core Components
+
+- **InteractActionBase** – Abstract base that wires UnityEvents, optional actor filtering, and per-action cooldowns. Derived actions call `SetEventListening()` in `Awake()` when they need specific events.
+- **InteractUtils** – Shared helpers for safe toggling of visuals, colliders, lights, particles, and UI canvas groups.
+- **InteractGizmos** – Optional scene gizmo that visualises the Interactable range and current toggle state.
+- **InteractionStateStore** – Lightweight static registry for sharing gate flags and counters across actions.
+
+## Action Library
+
+The following actions ship with default inspectors (all annotated and null-safe):
+
+1. DoorAction – Toggle visual states & collider on complete.
+2. MovingDoorAction – Animator-driven or manual moving door with cancel close.
+3. PlatformToggleAction – Toggle any target hierarchy active state.
+4. TimedSwitchAction – Enables a target for `durationMs` then reverts.
+5. ElevatorCallAction – Fires an Animator trigger and optional SFX.
+6. BridgeExtendAction – Toggle bridge visuals and colliders.
+7. CircuitPatchAction – Updates emissive glow using a MaterialPropertyBlock.
+8. ValveAction – Maps hold progress to rotation with cancel reset.
+9. ColorKeyAction – Validates a controller `ColorKeyRing` against a required ID.
+10. SequencePadAction – Broadcasts sequence step indices via UnityEvent.
+11. WeightCheckAction – Evaluates rigidbody mass inside a trigger area.
+12. TimeLeverAction – Scales `Time.timeScale` while held.
+13. DialogueAction – Invokes start/advance dialogue events.
+14. LogPickupAction – Adds collectibles and updates visuals once collected.
+15. CutsceneTriggerAction – Plays or restarts a Timeline director.
+16. MemoryFlashAction – Kicks an Animator trigger and updates overlay text.
+17. ChoiceAction – Presents a CanvasGroup-driven choice and stores the result gate.
+18. SfxAction – Plays configurable AudioSources on start/complete/cancel.
+19. MusicSnapshotAction – Transitions to an AudioMixer snapshot.
+20. LightToggleAction – Toggles light enable state & intensity.
+21. FlickerAction – Periodic flicker during interaction.
+22. ParticleBurstAction – Fires a particle burst on completion.
+23. CameraShakeAction – Triggers a Cinemachine impulse.
+24. ScreenFadeAction – Sets a CanvasGroup alpha for fades.
+25. CheckpointAction – Emits spawn positions via UnityEvent.
+26. SaveGameAction – Emits a generic save event.
+27. QuestAdvanceAction – Emits quest progression payloads.
+28. GateBoolAction – Writes boolean flags into the shared store.
+29. MultiGateAction – Checks flag combinations before invoking.
+30. CounterAction – Tracks repeated completes and fires when threshold reached.
+31. PromptHintAction – Shows/hides hint UI on focus events.
+32. ReticleSnapAction – Locks or releases aiming reticles via UnityEvents.
+33. SlowTimeAction – Quick slow-motion toggle.
+34. LogEventAction – Logs and profiles every interaction event.
+35. GizmoPulseAction – Scales focus gizmos on focus.
+
+## Editor Tooling
+
+- **InteractableInspector** lists attached actions and supplies quick buttons to add common setups (Door, Platform Toggle, Dialogue panel).
+- **Tools ▸ Interactions ▸ Create** menu spawns configured prefabs for Door, Moving Door, and Panel Trigger interactables.
+
+## Prefabs & UI
+
+Placeholder folders (`Assets/Prefabs/Interactions`, `Assets/UI/Interactions`) are ready for authoring reusable templates and UI overlays. Designers can duplicate objects from the demo scene into prefabs without extra wiring.
+
+## Demo Scene
+
+`Assets/Scenes/InteractionDemo.unity` (requires opening the project in Unity) showcases ten+ interaction nodes wired to `E` via the existing InteractionController. Each station demonstrates different action types (toggle, hold, timed switches, panels, gates, and FX).
+
+## Performance Notes
+
+- No per-frame allocations—the action base caches delegates and uses shared buffers/property blocks.
+- Event-driven approach: only `InteractionController.Tick()` runs per-frame, feeding Interactable UnityEvents to actions.
+- Utility methods guard against null references and redundant state changes to minimise work in the hot path.
+
+## Smoke Test Checklist
+
+1. Focus hints appear/disappear while stepping in/out of range.
+2. Tap, toggle, hold, and panel interactions complete with matching responses.
+3. Multiple interactables in range prioritise by `Interactable.priority`.
+4. Cancelling hold interactions resets associated state (door closes, timescale restored).
+5. Animator-driven doors keep collider state in sync with animation parameters.
+6. Actions remain dormant while disabled, respecting local cooldown settings.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# 2175 Interaction Nodes
+
+This branch introduces a modular, node-based interaction system layered on top of the existing `Interactable` and `InteractionController` components.
+
+## Highlights
+
+- 35 ready-to-use `InteractActionBase` behaviours covering world, puzzle, narrative, FX, game-state, and UX scenarios.
+- Event-driven architecture with optional actor filtering and per-action cooldowns.
+- Editor extensions listing attached actions with quick buttons plus menu items under **Tools ▸ Interactions ▸ Create** for rapid scene setup.
+- Demo scene: `Assets/Scenes/InteractionDemo.unity` showcases tap, toggle, hold, timed, puzzle, and FX interactions triggered with the **E** key.
+- Shared utilities (`InteractUtils`, `InteractionStateStore`, `InteractGizmos`) keep actions null-safe and allocation-free.
+
+See [Docs/Interactions.md](Docs/Interactions.md) for full documentation, setup notes, and a smoke test checklist.


### PR DESCRIPTION
## Summary
- add the InteractActionBase core along with utilities, gizmos, and shared state helpers for event-driven interactions
- implement a library of modular InteractAction behaviours covering world, puzzle, narrative, FX, game-state, and UX use cases
- ship editor tooling, documentation, and a demo scene to help designers wire interactions without additional scripting

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d854a3db3c83228782f60f53c4a25a