### PR TITLE
Refactor interaction system around modular actions

### DIFF
--- a/Assets/scripts/characterScripts/Interactable.cs
+++ b/Assets/scripts/characterScripts/Interactable.cs
@@ -1,19 +1,12 @@
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 public enum InteractionActor
 {
     Any,
     Elior,
     Sim
-}
-
-public enum InteractionType
-{
-    Tap,
-    Hold,
-    Toggle,
-    Panel
 }
 
 [System.Serializable]
@@ -26,7 +19,9 @@ public class Interactable : MonoBehaviour
 {
     [Header("Interaction Settings")]
     public InteractionActor requiredActor = InteractionActor.Any;
-    public InteractionType interactionType = InteractionType.Tap;
+    [FormerlySerializedAs("interactionType")]
+    [SerializeField]
+    InteractionType legacyInteractionType = InteractionType.Tap;
     [Tooltip("Maximum usable range for this interactable.")]
     public float range = 1.2f;
     public int priority = 0;
@@ -35,6 +30,9 @@ public class Interactable : MonoBehaviour
     public bool isLocked = false;
     [Tooltip("When true the interaction stays unlocked across sessions (handled externally).")]
     public bool persistent = false;
+
+    [Header("Interaction Action")]
+    public InteractionAction action;
 
     [Header("Events")]
     public InteractionControllerEvent OnFocusEnter;
@@ -46,6 +44,8 @@ public class Interactable : MonoBehaviour
 
     float cooldownRemaining;
     bool toggleState;
+    InteractionAction runtimeAction;
+    InteractionController activeController;
 
     public bool IsLocked => isLocked;
     public bool IsOnCooldown => cooldownRemaining > 0f;
@@ -57,6 +57,9 @@ public class Interactable : MonoBehaviour
         {
             cooldownRemaining = Mathf.Max(0f, cooldownRemaining - dtMs);
         }
+
+        var instance = GetActionInstance();
+        instance?.Tick(this, dtMs);
     }
 
     public void BeginCooldown()
@@ -71,51 +74,142 @@ public class Interactable : MonoBehaviour
 
     public void NotifyFocusEnter(InteractionController controller)
     {
+        var context = CreateContext(controller);
+        GetActionInstance()?.OnFocusEnter(context);
         OnFocusEnter?.Invoke(controller);
     }
 
     public void NotifyFocusExit(InteractionController controller)
     {
+        var context = CreateContext(controller);
+        GetActionInstance()?.OnFocusExit(context);
         OnFocusExit?.Invoke(controller);
     }
 
     public void NotifyStart(InteractionController controller)
     {
+        var context = CreateContext(controller);
+        GetActionInstance()?.OnStart(context);
+        activeController = controller;
         OnInteractStart?.Invoke(controller);
     }
 
     public void NotifyProgress(float t)
     {
+        var context = CreateContext(activeController);
+        GetActionInstance()?.OnProgress(context, t);
         OnInteractProgress?.Invoke(t);
     }
 
     public void NotifyComplete(InteractionController controller)
     {
-        switch (interactionType)
-        {
-            case InteractionType.Toggle:
-                toggleState = !toggleState;
-                break;
-            case InteractionType.Hold:
-            case InteractionType.Panel:
-                toggleState = true;
-                break;
-            default:
-                toggleState = false;
-                break;
-        }
+        var context = CreateContext(controller);
+        GetActionInstance()?.OnComplete(context);
         OnInteractComplete?.Invoke(controller);
+        if (activeController == controller)
+            activeController = null;
     }
 
     public void NotifyCancel(InteractionController controller)
     {
-        if (interactionType == InteractionType.Hold || interactionType == InteractionType.Panel)
-            toggleState = false;
+        var context = CreateContext(controller);
+        GetActionInstance()?.OnCancel(context);
         OnInteractCancel?.Invoke(controller);
+        if (activeController == controller)
+            activeController = null;
     }
 
     public void ForceToggleState(bool value)
     {
         toggleState = value;
+    }
+
+    public InteractionActionMode ActionMode
+    {
+        get
+        {
+            var instance = GetActionInstance();
+            return instance ? instance.Mode : InteractionActionMode.Instant;
+        }
+    }
+
+    public InteractionAbilityRequirement AbilityRequirement
+    {
+        get
+        {
+            var instance = GetActionInstance();
+            return instance ? instance.RequiredAbility : InteractionAbilityRequirement.Interact;
+        }
+    }
+
+    public bool LocksMovement
+    {
+        get
+        {
+            var instance = GetActionInstance();
+            return instance && instance.LocksMovement;
+        }
+    }
+
+    public bool CanExecute(InteractionController controller)
+    {
+        var instance = GetActionInstance();
+        if (!instance)
+            return true;
+        var context = CreateContext(controller);
+        return instance.CanExecute(context);
+    }
+
+    public float GetRequiredHoldDurationMs(InteractionController controller)
+    {
+        var instance = GetActionInstance();
+        if (!instance)
+            return holdDurationMs;
+        var context = CreateContext(controller);
+        return instance.GetRequiredHoldDurationMs(context);
+    }
+
+    InteractionAction GetActionInstance()
+    {
+        if (!runtimeAction)
+        {
+            runtimeAction = CreateActionInstance();
+            runtimeAction?.Initialize(this);
+        }
+        return runtimeAction;
+    }
+
+    InteractionAction CreateActionInstance()
+    {
+        if (action)
+        {
+            var instance = Instantiate(action);
+            instance.hideFlags = HideFlags.DontUnloadUnusedAsset | HideFlags.HideAndDontSave;
+            return instance;
+        }
+
+        switch (legacyInteractionType)
+        {
+            case InteractionType.Toggle:
+                return CreateRuntimeAction<ToggleInteractionAction>();
+            case InteractionType.Hold:
+                return CreateRuntimeAction<HoldInteractionAction>();
+            case InteractionType.Panel:
+                return CreateRuntimeAction<PanelInteractionAction>();
+            default:
+                return CreateRuntimeAction<TapInteractionAction>();
+        }
+    }
+
+    InteractionAction CreateRuntimeAction<T>() where T : InteractionAction
+    {
+        var created = ScriptableObject.CreateInstance<T>();
+        created.hideFlags = HideFlags.DontUnloadUnusedAsset | HideFlags.HideAndDontSave;
+        return created;
+    }
+
+    InteractionContext CreateContext(InteractionController controller)
+    {
+        return new InteractionContext(controller, this);
     }
 }

--- a/Assets/scripts/characterScripts/InteractionAction.cs
+++ b/Assets/scripts/characterScripts/InteractionAction.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+public enum InteractionAbilityRequirement
+{
+    Interact,
+    Panel
+}
+
+public enum InteractionActionMode
+{
+    Instant,
+    Hold
+}
+
+public readonly struct InteractionContext
+{
+    public readonly InteractionController Controller;
+    public readonly Interactable Interactable;
+
+    public InteractionContext(InteractionController controller, Interactable interactable)
+    {
+        Controller = controller;
+        Interactable = interactable;
+    }
+}
+
+public abstract class InteractionAction : ScriptableObject
+{
+    public virtual void Initialize(Interactable interactable) { }
+
+    public virtual void Tick(Interactable interactable, float dtMs) { }
+
+    public virtual void OnFocusEnter(InteractionContext context) { }
+
+    public virtual void OnFocusExit(InteractionContext context) { }
+
+    public virtual void OnStart(InteractionContext context) { }
+
+    public virtual void OnProgress(InteractionContext context, float normalizedProgress) { }
+
+    public virtual void OnComplete(InteractionContext context) { }
+
+    public virtual void OnCancel(InteractionContext context) { }
+
+    public virtual bool CanExecute(InteractionContext context) => true;
+
+    public virtual InteractionAbilityRequirement RequiredAbility => InteractionAbilityRequirement.Interact;
+
+    public virtual InteractionActionMode Mode => InteractionActionMode.Instant;
+
+    public virtual bool LocksMovement => false;
+
+    public virtual float GetRequiredHoldDurationMs(InteractionContext context)
+    {
+        return context.Interactable ? context.Interactable.holdDurationMs : 0f;
+    }
+}

--- a/Assets/scripts/characterScripts/InteractionActions/HoldInteractionAction.cs
+++ b/Assets/scripts/characterScripts/InteractionActions/HoldInteractionAction.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Interactions/Basma-Tutma Etkilesimi", fileName = "HoldInteractionAction")]
+public class HoldInteractionAction : InteractionAction
+{
+    public override InteractionActionMode Mode => InteractionActionMode.Hold;
+
+    public override void OnComplete(InteractionContext context)
+    {
+        if (context.Interactable)
+        {
+            context.Interactable.ForceToggleState(true);
+        }
+    }
+
+    public override void OnCancel(InteractionContext context)
+    {
+        if (context.Interactable)
+        {
+            context.Interactable.ForceToggleState(false);
+        }
+    }
+}

--- a/Assets/scripts/characterScripts/InteractionActions/PanelInteractionAction.cs
+++ b/Assets/scripts/characterScripts/InteractionActions/PanelInteractionAction.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Interactions/Panel Etkilesimi", fileName = "PanelInteractionAction")]
+public class PanelInteractionAction : HoldInteractionAction
+{
+    public override InteractionAbilityRequirement RequiredAbility => InteractionAbilityRequirement.Panel;
+
+    public override bool LocksMovement => true;
+}

--- a/Assets/scripts/characterScripts/InteractionActions/TapInteractionAction.cs
+++ b/Assets/scripts/characterScripts/InteractionActions/TapInteractionAction.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Interactions/Tap Etkilesimi", fileName = "TapInteractionAction")]
+public class TapInteractionAction : InteractionAction
+{
+    public override void OnComplete(InteractionContext context)
+    {
+        if (context.Interactable)
+        {
+            context.Interactable.ForceToggleState(false);
+        }
+    }
+}

--- a/Assets/scripts/characterScripts/InteractionActions/ToggleInteractionAction.cs
+++ b/Assets/scripts/characterScripts/InteractionActions/ToggleInteractionAction.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Interactions/Anahtar Etkilesimi", fileName = "ToggleInteractionAction")]
+public class ToggleInteractionAction : InteractionAction
+{
+    public override void OnComplete(InteractionContext context)
+    {
+        if (context.Interactable)
+        {
+            bool nextState = !context.Interactable.ToggleState;
+            context.Interactable.ForceToggleState(nextState);
+        }
+    }
+}

--- a/Assets/scripts/characterScripts/InteractionType.cs
+++ b/Assets/scripts/characterScripts/InteractionType.cs
@@ -1,0 +1,7 @@
+public enum InteractionType
+{
+    Tap,
+    Hold,
+    Toggle,
+    Panel
+}

--- a/Assets/scripts/characterScripts/PowerNode.cs
+++ b/Assets/scripts/characterScripts/PowerNode.cs
@@ -54,7 +54,7 @@ public class PowerNode : MonoBehaviour
     {
         if (!controller)
             return;
-        if (interactable.interactionType == InteractionType.Toggle)
+        if (interactable.ActionMode == InteractionActionMode.Instant)
             return;
 
         if (powered)


### PR DESCRIPTION
## Summary
- rework Interactable to instantiate modular `InteractionAction` assets and expose helper APIs while keeping legacy enum data for fallback
- add ScriptableObject implementations for tap, toggle, hold, and panel behaviours and update the controller to drive them
- align dependent logic such as PowerNode cancellation with the new action mode helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a498bae4832297bb1b0cc08a35dd